### PR TITLE
feat: implement scoped task keys (Jira-style IDs)

### DIFF
--- a/app/(admin)/tasks/[taskKey]/page.tsx
+++ b/app/(admin)/tasks/[taskKey]/page.tsx
@@ -15,9 +15,9 @@ import { TaskTimeEntries } from "@/components/time/TaskTimeEntries";
 export default async function TaskDetailPage({
   params,
 }: {
-  params: Promise<{ taskId: string }>;
+  params: Promise<{ taskKey: string }>;
 }) {
-  const { taskId } = await params;
+  const { taskKey } = await params;
   const supabase = await createClient();
 
   const {
@@ -26,11 +26,28 @@ export default async function TaskDetailPage({
 
   if (!user) notFound();
 
+  // Parse "AC-42" → clientKey="AC", taskNumber=42
+  const dashIdx = taskKey.lastIndexOf("-");
+  if (dashIdx === -1) notFound();
+  const clientKey = taskKey.slice(0, dashIdx).toUpperCase();
+  const taskNumber = parseInt(taskKey.slice(dashIdx + 1), 10);
+  if (!clientKey || isNaN(taskNumber)) notFound();
+
+  // Look up the client first (scoped to the user's tenant via RLS)
+  const { data: clientRow } = await supabase
+    .from("clients")
+    .select("id")
+    .eq("client_key", clientKey)
+    .single();
+
+  if (!clientRow) notFound();
+
   const [{ data: task, error }, { data: profile }] = await Promise.all([
     supabase
       .from("tasks")
-      .select("*, clients(id, name, color, tenant_id, tenants(id))")
-      .eq("id", taskId)
+      .select("*, clients(id, name, color, client_key, tenant_id, tenants(id))")
+      .eq("client_id", clientRow.id)
+      .eq("task_number", taskNumber)
       .single(),
     supabase.from("profiles").select("tenant_id").eq("id", user.id).single(),
   ]);
@@ -41,10 +58,12 @@ export default async function TaskDetailPage({
     id: string;
     name: string;
     color: string | null;
+    client_key: string | null;
     tenant_id: string;
     tenants: { id: string } | null;
   } | null;
 
+  const taskId = task.id as string;
   const tenantId = profile?.tenant_id ?? client?.tenant_id ?? "";
 
   const [
@@ -82,10 +101,13 @@ export default async function TaskDetailPage({
   ]);
 
   const isClosed = task.status === "closed";
+  const displayKey = client?.client_key
+    ? `${client.client_key}-${task.task_number}`
+    : null;
 
   function formatDate(d: string | null) {
     if (!d) return "—";
-    return new Date(d).toLocaleDateString(undefined, {
+    return new Date(d).toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
       year: "numeric",
@@ -96,7 +118,11 @@ export default async function TaskDetailPage({
     <>
       <TopBar
         title={task.title}
-        description={client?.name}
+        description={
+          displayKey && client
+            ? `${displayKey} · ${client.name}`
+            : client?.name
+        }
         actions={
           !isClosed && (
             <CloseTaskDialog
@@ -143,6 +169,12 @@ export default async function TaskDetailPage({
               </div>
             </dl>
             <dl className="space-y-2">
+              <div className="flex gap-4">
+                <dt className="w-28 shrink-0 text-muted-foreground">Task ID</dt>
+                <dd className="font-mono text-xs text-muted-foreground pt-0.5">
+                  {displayKey ?? "—"}
+                </dd>
+              </div>
               <div className="flex gap-4">
                 <dt className="w-28 shrink-0 text-muted-foreground">Due date</dt>
                 <dd className={task.due_date && !isClosed && new Date(task.due_date) < new Date() ? "text-red-600 dark:text-red-400 font-medium" : "text-foreground"}>

--- a/app/(admin)/tasks/page.tsx
+++ b/app/(admin)/tasks/page.tsx
@@ -26,7 +26,7 @@ export default async function TasksPage({
 
   let query = supabase
     .from("tasks")
-    .select("id, title, status, priority, due_date, created_at, clients(name, color)")
+    .select("id, task_number, title, status, priority, due_date, created_at, clients(name, color, client_key)")
     .order("created_at", { ascending: false });
 
   if (q) query = query.ilike("title", `%${q}%`);

--- a/app/actions/clients.ts
+++ b/app/actions/clients.ts
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/server";
 
 interface ClientFields {
   name: string;
+  client_key: string;
   company: string;
   email: string;
   phone: string;
@@ -22,9 +23,21 @@ interface ClientFields {
   billing_country: string;
 }
 
+const CLIENT_KEY_RE = /^[A-Z0-9]{2,10}$/;
+
+function validateClientKey(key: string): string | null {
+  const normalized = key.trim().toUpperCase();
+  if (!normalized) return "Client key is required.";
+  if (!CLIENT_KEY_RE.test(normalized)) {
+    return "Client key must be 2–10 uppercase letters or digits (e.g. AC, ACME).";
+  }
+  return null;
+}
+
 function buildClientPayload(fields: ClientFields) {
   return {
     name: fields.name.trim(),
+    client_key: fields.client_key.trim().toUpperCase() || null,
     company: fields.company.trim() || null,
     email: fields.email.trim() || null,
     phone: fields.phone.trim() || null,
@@ -66,7 +79,7 @@ export async function createClientAction(
   if (!profile) return { error: "Profile not found." };
 
   const keys = [
-    "name", "company", "email", "phone", "default_rate", "payment_terms",
+    "name", "client_key", "company", "email", "phone", "default_rate", "payment_terms",
     "currency", "color", "notes", "billing_line1", "billing_line2",
     "billing_city", "billing_state", "billing_postal_code", "billing_country",
   ] as const;
@@ -75,6 +88,9 @@ export async function createClientAction(
   ) as unknown as ClientFields;
 
   if (!fields.name.trim()) return { error: "Client name is required." };
+
+  const keyError = validateClientKey(fields.client_key);
+  if (keyError) return { error: keyError };
 
   const { data, error } = await supabase
     .from("clients")
@@ -103,7 +119,7 @@ export async function updateClientAction(
   }
 
   const keys = [
-    "name", "company", "email", "phone", "default_rate", "payment_terms",
+    "name", "client_key", "company", "email", "phone", "default_rate", "payment_terms",
     "currency", "color", "notes", "billing_line1", "billing_line2",
     "billing_city", "billing_state", "billing_postal_code", "billing_country",
   ] as const;
@@ -112,6 +128,11 @@ export async function updateClientAction(
   ) as unknown as ClientFields;
 
   if (!fields.name.trim()) return { error: "Client name is required." };
+
+  if (fields.client_key.trim()) {
+    const keyError = validateClientKey(fields.client_key);
+    if (keyError) return { error: keyError };
+  }
 
   const { error } = await supabase
     .from("clients")

--- a/app/actions/comments.ts
+++ b/app/actions/comments.ts
@@ -2,6 +2,23 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+async function getTaskSlug(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any>,
+  taskId: string
+): Promise<string> {
+  const { data } = await supabase
+    .from("tasks")
+    .select("task_number, clients(client_key)")
+    .eq("id", taskId)
+    .single();
+  if (!data) return taskId;
+  const c = data.clients as unknown as { client_key: string | null } | null;
+  if (!c?.client_key || data.task_number == null) return taskId;
+  return `${c.client_key}-${data.task_number}`;
+}
 
 export async function createCommentAction(
   taskId: string,
@@ -36,7 +53,8 @@ export async function createCommentAction(
 
   if (error) return { error: error.message };
 
-  revalidatePath(`/tasks/${taskId}`);
+  const slug = await getTaskSlug(supabase, taskId);
+  revalidatePath(`/tasks/${slug}`);
   return {};
 }
 
@@ -59,6 +77,7 @@ export async function deleteCommentAction(
 
   if (error) return { error: error.message };
 
-  revalidatePath(`/tasks/${taskId}`);
+  const slug = await getTaskSlug(supabase, taskId);
+  revalidatePath(`/tasks/${slug}`);
   return {};
 }

--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -3,6 +3,31 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the human-readable task key (e.g. "AC-1") for a given task UUID.
+ * Used by server actions to build the correct revalidatePath argument.
+ * Falls back to the raw UUID on any error so revalidation still runs.
+ */
+async function getTaskSlug(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any>,
+  taskId: string
+): Promise<string> {
+  const { data } = await supabase
+    .from("tasks")
+    .select("task_number, clients(client_key)")
+    .eq("id", taskId)
+    .single();
+
+  if (!data) return taskId;
+  const c = data.clients as unknown as { client_key: string | null } | null;
+  if (!c?.client_key || data.task_number == null) return taskId;
+  return `${c.client_key}-${data.task_number}`;
+}
 
 // ─── Create ──────────────────────────────────────────────────────────────────
 
@@ -36,6 +61,12 @@ export async function createTaskAction(
   const estimated_hours = formData.get("estimated_hours") as string;
   const priority = (formData.get("priority") as string) || "medium";
 
+  // Atomically claim the next task number for this client
+  const { data: taskNumber, error: numError } = await supabase
+    .rpc("next_task_number_for_client", { p_client_id: client_id });
+
+  if (numError) return { error: numError.message };
+
   const { data, error } = await supabase
     .from("tasks")
     .insert({
@@ -45,14 +76,21 @@ export async function createTaskAction(
       priority,
       due_date: due_date || null,
       estimated_hours: estimated_hours ? parseFloat(estimated_hours) : null,
+      task_number: taskNumber,
     })
-    .select("id")
+    .select("id, task_number, clients(client_key)")
     .single();
 
   if (error) return { error: error.message };
 
+  const c = data.clients as unknown as { client_key: string | null } | null;
+  const slug =
+    c?.client_key && data.task_number != null
+      ? `${c.client_key}-${data.task_number}`
+      : data.id;
+
   revalidatePath("/tasks");
-  redirect(`/tasks/${data.id}`);
+  redirect(`/tasks/${slug}`);
 }
 
 // ─── Update metadata ──────────────────────────────────────────────────────────
@@ -92,7 +130,8 @@ export async function updateTaskMetaAction(
 
   if (error) return { error: error.message };
 
-  revalidatePath(`/tasks/${taskId}`);
+  const slug = await getTaskSlug(supabase, taskId);
+  revalidatePath(`/tasks/${slug}`);
   revalidatePath("/tasks");
   return {};
 }
@@ -120,7 +159,8 @@ export async function updateTaskContentAction(
 
   if (error) return { error: error.message };
 
-  revalidatePath(`/tasks/${taskId}`);
+  const slug = await getTaskSlug(supabase, taskId);
+  revalidatePath(`/tasks/${slug}`);
   return {};
 }
 
@@ -153,7 +193,8 @@ export async function updateTaskStatusAction(
 
   if (error) return { error: error.message };
 
-  revalidatePath(`/tasks/${taskId}`);
+  const slug = await getTaskSlug(supabase, taskId);
+  revalidatePath(`/tasks/${slug}`);
   revalidatePath("/tasks");
   return {};
 }
@@ -196,7 +237,8 @@ export async function closeTaskAction(
     // Email failure should not block the close action
   }
 
-  revalidatePath(`/tasks/${taskId}`);
+  const slug = await getTaskSlug(supabase, taskId);
+  revalidatePath(`/tasks/${slug}`);
   revalidatePath("/tasks");
   return {};
 }
@@ -254,7 +296,8 @@ export async function saveAttachmentAction(params: {
 
   if (error) return { error: error.message };
 
-  revalidatePath(`/tasks/${params.taskId}`);
+  const slug = await getTaskSlug(supabase, params.taskId);
+  revalidatePath(`/tasks/${slug}`);
   return {};
 }
 
@@ -280,6 +323,7 @@ export async function deleteAttachmentAction(
 
   if (error) return { error: error.message };
 
-  revalidatePath(`/tasks/${taskId}`);
+  const slug = await getTaskSlug(supabase, taskId);
+  revalidatePath(`/tasks/${slug}`);
   return {};
 }

--- a/app/actions/time.ts
+++ b/app/actions/time.ts
@@ -2,6 +2,23 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+async function getTaskSlug(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any>,
+  taskId: string
+): Promise<string> {
+  const { data } = await supabase
+    .from("tasks")
+    .select("task_number, clients(client_key)")
+    .eq("id", taskId)
+    .single();
+  if (!data) return taskId;
+  const c = data.clients as unknown as { client_key: string | null } | null;
+  if (!c?.client_key || data.task_number == null) return taskId;
+  return `${c.client_key}-${data.task_number}`;
+}
 
 interface TimeEntryInput {
   client_id: string;
@@ -53,7 +70,10 @@ export async function createTimeEntryAction(
   if (error) return { error: error.message };
 
   revalidatePath("/time");
-  if (input.task_id) revalidatePath(`/tasks/${input.task_id}`);
+  if (input.task_id) {
+    const slug = await getTaskSlug(supabase, input.task_id);
+    revalidatePath(`/tasks/${slug}`);
+  }
   return { id: data.id };
 }
 
@@ -88,7 +108,10 @@ export async function updateTimeEntryAction(
   if (error) return { error: error.message };
 
   revalidatePath("/time");
-  if (input.task_id) revalidatePath(`/tasks/${input.task_id}`);
+  if (input.task_id) {
+    const slug = await getTaskSlug(supabase, input.task_id);
+    revalidatePath(`/tasks/${slug}`);
+  }
   return {};
 }
 
@@ -138,6 +161,9 @@ export async function deleteTimeEntryAction(
   if (error) return { error: error.message };
 
   revalidatePath("/time");
-  if (taskId) revalidatePath(`/tasks/${taskId}`);
+  if (taskId) {
+    const slug = await getTaskSlug(supabase, taskId);
+    revalidatePath(`/tasks/${slug}`);
+  }
   return {};
 }

--- a/components/clients/ClientForm.tsx
+++ b/components/clients/ClientForm.tsx
@@ -20,6 +20,7 @@ import {
 interface ClientData {
   id?: string;
   name?: string;
+  client_key?: string | null;
   company?: string;
   email?: string;
   phone?: string;
@@ -94,6 +95,27 @@ export function ClientForm({ action, client, cancelHref }: ClientFormProps) {
               placeholder="Jane Smith"
             />
           </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="client_key">
+              Client key <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="client_key"
+              name="client_key"
+              required={!client?.id}
+              defaultValue={client?.client_key ?? ""}
+              placeholder="AC"
+              className="uppercase"
+              maxLength={10}
+            />
+            <p className="text-xs text-muted-foreground">
+              2–10 letters/digits used as task ID prefix — e.g.{" "}
+              <span className="font-mono">AC-1</span>
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
           <div className="space-y-1.5">
             <Label htmlFor="company">Company</Label>
             <Input

--- a/components/tasks/TaskBoardView.tsx
+++ b/components/tasks/TaskBoardView.tsx
@@ -3,11 +3,18 @@ import { TaskPriorityBadge } from "./TaskStatusBadge";
 
 interface Task {
   id: string;
+  task_number: number | null;
   title: string;
   status: string;
   priority: string;
   due_date: string | null;
-  clients: { name: string; color: string | null } | null;
+  clients: { name: string; color: string | null; client_key: string | null } | null;
+}
+
+function taskHref(task: Task) {
+  const key = task.clients?.client_key;
+  if (key && task.task_number != null) return `/tasks/${key}-${task.task_number}`;
+  return `/tasks/${task.id}`;
 }
 
 const COLUMNS = [
@@ -34,9 +41,14 @@ function TaskCard({ task }: { task: Task }) {
   const overdue = isPastDue(task.due_date, task.status);
   return (
     <Link
-      href={`/tasks/${task.id}`}
+      href={taskHref(task)}
       className="block rounded-md border border-border bg-card p-3 shadow-sm hover:shadow-md hover:border-accent transition-all space-y-2"
     >
+      {task.clients?.client_key && task.task_number != null && (
+        <p className="font-mono text-[10px] text-muted-foreground">
+          {task.clients.client_key}-{task.task_number}
+        </p>
+      )}
       <p className="text-sm font-medium text-foreground leading-snug">{task.title}</p>
       <div className="flex items-center justify-between gap-2">
         <TaskPriorityBadge priority={task.priority} />

--- a/components/tasks/TaskListView.tsx
+++ b/components/tasks/TaskListView.tsx
@@ -4,12 +4,19 @@ import { TaskStatusBadge, TaskPriorityBadge } from "./TaskStatusBadge";
 
 interface Task {
   id: string;
+  task_number: number | null;
   title: string;
   status: string;
   priority: string;
   due_date: string | null;
   created_at: string;
-  clients: { name: string; color: string | null } | null;
+  clients: { name: string; color: string | null; client_key: string | null } | null;
+}
+
+function taskHref(task: Task) {
+  const key = task.clients?.client_key;
+  if (key && task.task_number != null) return `/tasks/${key}-${task.task_number}`;
+  return `/tasks/${task.id}`;
 }
 
 function formatDate(d: string | null) {
@@ -43,6 +50,7 @@ export function TaskListView({ tasks }: { tasks: Task[] }) {
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-border bg-muted/40">
+            <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground w-20">ID</th>
             <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Title</th>
             <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Client</th>
             <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Status</th>
@@ -55,8 +63,17 @@ export function TaskListView({ tasks }: { tasks: Task[] }) {
           {tasks.map((task) => (
             <tr key={task.id} className="group hover:bg-muted/30 transition-colors">
               <td className="px-4 py-3">
+                {task.clients?.client_key && task.task_number != null ? (
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {task.clients.client_key}-{task.task_number}
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">—</span>
+                )}
+              </td>
+              <td className="px-4 py-3">
                 <Link
-                  href={`/tasks/${task.id}`}
+                  href={taskHref(task)}
                   className="font-medium text-foreground hover:underline"
                 >
                   {task.title}
@@ -83,7 +100,7 @@ export function TaskListView({ tasks }: { tasks: Task[] }) {
                 {formatDate(task.due_date)}
               </td>
               <td className="pr-3">
-                <Link href={`/tasks/${task.id}`}>
+                <Link href={taskHref(task)}>
                   <ChevronRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
                 </Link>
               </td>

--- a/supabase/migrations/20260303000005_task_keys.sql
+++ b/supabase/migrations/20260303000005_task_keys.sql
@@ -1,0 +1,88 @@
+-- ─── Phase: Scoped Task Keys (Issue #10) ─────────────────────────────────────
+--
+-- Adds a human-readable Jira-style ID to every task, scoped to the client
+-- (e.g. "AC-1", "AC-2"). Two changes to the schema:
+--
+--  1. clients.client_key  – short uppercase alphanumeric prefix chosen by the
+--                           user when creating a client (e.g. "AC").
+--  2. clients.next_task_number – atomic counter: incremented every time a task
+--                                is created for this client.
+--  3. tasks.task_number   – the sequential integer portion of the task key.
+--
+-- Uniqueness is enforced at the DB level:
+--   • (tenant_id, client_key)  — keys are unique within a tenant
+--   • (client_id, task_number) — numbers are unique within a client
+
+-- ── 1. Add client_key to clients ──────────────────────────────────────────────
+
+ALTER TABLE clients
+  ADD COLUMN IF NOT EXISTS client_key        TEXT,
+  ADD COLUMN IF NOT EXISTS next_task_number  INTEGER NOT NULL DEFAULT 1;
+
+-- Unique key per tenant (allows NULL during backfill / migration window)
+CREATE UNIQUE INDEX IF NOT EXISTS clients_tenant_client_key_key
+  ON clients (tenant_id, client_key)
+  WHERE client_key IS NOT NULL;
+
+-- ── 2. Add task_number to tasks ───────────────────────────────────────────────
+
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS task_number  INTEGER;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tasks_client_task_number_key
+  ON tasks (client_id, task_number)
+  WHERE task_number IS NOT NULL;
+
+-- ── 3. Atomic counter function ────────────────────────────────────────────────
+--
+-- Returns the next task number for a given client and bumps the counter.
+-- The UPDATE is a single atomic operation so two concurrent calls always
+-- receive distinct numbers.
+
+CREATE OR REPLACE FUNCTION next_task_number_for_client(p_client_id UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_num INTEGER;
+BEGIN
+  UPDATE clients
+  SET    next_task_number = next_task_number + 1
+  WHERE  id = p_client_id
+  RETURNING next_task_number - 1 INTO v_num;
+
+  IF v_num IS NULL THEN
+    RAISE EXCEPTION 'Client % not found', p_client_id;
+  END IF;
+
+  RETURN v_num;
+END;
+$$;
+
+-- ── 4. Backfill existing tasks ────────────────────────────────────────────────
+--
+-- Assign sequential task_number values to tasks that don't have one yet,
+-- ordered by created_at within each client.
+
+DO $$
+DECLARE
+  r RECORD;
+  v_num INTEGER;
+BEGIN
+  FOR r IN
+    SELECT id, client_id
+    FROM   tasks
+    WHERE  task_number IS NULL
+    ORDER  BY client_id, created_at
+  LOOP
+    -- Allocate next number for this client atomically
+    v_num := next_task_number_for_client(r.client_id);
+
+    UPDATE tasks
+    SET    task_number = v_num
+    WHERE  id = r.id;
+  END LOOP;
+END;
+$$;


### PR DESCRIPTION
Closes #10

## Summary

- **Client key**: Users now set a 2–10 char uppercase prefix (e.g. `AC`) when creating a client. This is validated as unique per tenant.
- **Task numbers**: Each task created under a client gets an atomic, sequential integer via a `SECURITY DEFINER` Postgres function (`next_task_number_for_client`). No duplicates are possible even under concurrent load.
- **Human-readable URLs**: Task detail pages moved from `/tasks/<uuid>` to `/tasks/<CLIENT_KEY>-<number>` (e.g. `/tasks/AC-1`).
- **Backfill**: Existing tasks are assigned sequential numbers (ordered by `created_at` within each client) by the migration.

## Changes

### Database (`20260303000005_task_keys.sql`)
- `clients.client_key TEXT` — nullable initially; partial unique index on `(tenant_id, client_key)`
- `clients.next_task_number INTEGER DEFAULT 1` — atomic counter
- `tasks.task_number INTEGER` — partial unique index on `(client_id, task_number)`
- `next_task_number_for_client(UUID)` — atomic `UPDATE … RETURNING` function
- DO block backfills all existing tasks

### Routing
- `app/(admin)/tasks/[taskId]/` → `app/(admin)/tasks/[taskKey]/`
- Page parses `AC-1` → looks up client by `client_key`, then task by `task_number`

### UI
- **Client form**: new required "Client key" field with format hint and validation
- **Task list view**: ID column (`AC-1`) added before the title
- **Task board view**: key badge at top of each card
- **Task detail**: "Task ID" row in the meta panel; description bar shows `AC-1 · Client Name`

### Actions / revalidation
- `createTaskAction`: calls RPC to claim next number, redirects to key URL
- All `revalidatePath('/tasks/…')` calls in `tasks.ts`, `comments.ts`, and `time.ts` updated to resolve the human-readable slug via a shared `getTaskSlug` helper

## Test plan
- [ ] Create a new client — verify "Client key" field is present and required
- [ ] Attempt invalid key (lowercase, special chars, too short/long) — should show error
- [ ] Create a task for that client — verify redirect lands on `/tasks/AC-1`
- [ ] Create a second task — verify it lands on `/tasks/AC-2`
- [ ] Task list: verify ID column shows `AC-1`, `AC-2`, links navigate correctly
- [ ] Task board: verify key badge visible on cards, links work
- [ ] Existing tasks (if any): verify they received sequential numbers and are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)