### PR TITLE
feat: perceived performance — loading skeletons, Suspense streaming, optimistic UI

### DIFF
--- a/app/(admin)/tasks/[taskKey]/loading.tsx
+++ b/app/(admin)/tasks/[taskKey]/loading.tsx
@@ -1,0 +1,94 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-6">
+        <div className="space-y-1.5">
+          <div className="h-4 w-48 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-24 rounded bg-muted/50 animate-pulse" />
+        </div>
+        <div className="h-7 w-24 rounded bg-muted/50 animate-pulse" />
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-6">
+        <div className="max-w-4xl space-y-8">
+          {/* Meta panel */}
+          <div className="grid grid-cols-2 gap-6 rounded-md border border-border bg-muted/20 px-5 py-4">
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex gap-4 items-center">
+                  <div className="h-3 w-28 shrink-0 rounded bg-muted/60 animate-pulse" />
+                  <div className="h-5 w-20 rounded-full bg-muted/40 animate-pulse" />
+                </div>
+              ))}
+            </div>
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex gap-4 items-center">
+                  <div className="h-3 w-28 shrink-0 rounded bg-muted/60 animate-pulse" />
+                  <div className="h-3 w-24 rounded bg-muted/50 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Separator */}
+          <div className="h-px bg-border" />
+
+          {/* Editors */}
+          <div className="space-y-6">
+            <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+            <div className="h-24 rounded-md bg-muted/30 animate-pulse" />
+            <div className="h-2.5 w-32 rounded bg-muted animate-pulse" />
+            <div className="h-24 rounded-md bg-muted/30 animate-pulse" />
+          </div>
+
+          {/* Separator */}
+          <div className="h-px bg-border" />
+
+          {/* Attachments */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+              <div className="h-6 w-20 rounded bg-muted/40 animate-pulse" />
+            </div>
+            <div className="h-12 rounded-md border border-dashed border-border bg-muted/10 animate-pulse" />
+          </div>
+
+          {/* Separator */}
+          <div className="h-px bg-border" />
+
+          {/* Time entries */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+              <div className="h-6 w-24 rounded bg-muted/40 animate-pulse" />
+            </div>
+            <div className="h-20 rounded-md border border-dashed border-border bg-muted/10 animate-pulse" />
+          </div>
+
+          {/* Separator */}
+          <div className="h-px bg-border" />
+
+          {/* Comments */}
+          <div className="space-y-3">
+            <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+            <div className="divide-y divide-border rounded-md border border-border">
+              {[1, 2].map((i) => (
+                <div key={i} className="flex gap-3 px-3 py-3">
+                  <div className="h-7 w-7 shrink-0 rounded-full bg-muted animate-pulse" />
+                  <div className="flex-1 space-y-1.5">
+                    <div className="h-2.5 w-32 rounded bg-muted animate-pulse" />
+                    <div className="h-3.5 w-full rounded bg-muted/60 animate-pulse" />
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="h-20 rounded-md border border-border bg-muted/10 animate-pulse" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/tasks/[taskKey]/page.tsx
+++ b/app/(admin)/tasks/[taskKey]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
@@ -11,6 +12,149 @@ import { TaskEditors } from "@/components/tasks/TaskEditors";
 import { AttachmentsList } from "@/components/tasks/AttachmentsList";
 import { CommentThread } from "@/components/comments/CommentThread";
 import { TaskTimeEntries } from "@/components/time/TaskTimeEntries";
+
+function formatDate(d: string | null) {
+  if (!d) return "—";
+  return new Date(d).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+// ─── Deferred async panel wrappers ────────────────────────────────────────────
+
+async function AttachmentsPanel({
+  taskId,
+  tenantId,
+}: {
+  taskId: string;
+  tenantId: string;
+}) {
+  const supabase = await createClient();
+  const { data: attachments } = await supabase
+    .from("task_attachments")
+    .select("id, file_name, file_size, mime_type, public_url, created_at")
+    .eq("task_id", taskId)
+    .order("created_at", { ascending: true });
+
+  return (
+    <AttachmentsList
+      taskId={taskId}
+      tenantId={tenantId}
+      attachments={attachments ?? []}
+    />
+  );
+}
+
+async function TimeEntriesPanel({
+  taskId,
+  clientId,
+}: {
+  taskId: string;
+  clientId: string;
+}) {
+  const supabase = await createClient();
+  const [{ data: timeEntries }, { data: allClients }, { data: openTasks }] =
+    await Promise.all([
+      supabase
+        .from("time_entries")
+        .select("id, description, entry_date, duration_hours, billable, billed, hourly_rate")
+        .eq("task_id", taskId)
+        .order("entry_date", { ascending: false }),
+      supabase
+        .from("clients")
+        .select("id, name, color, default_rate")
+        .eq("is_archived", false)
+        .order("name"),
+      supabase
+        .from("tasks")
+        .select("id, title, client_id")
+        .not("status", "eq", "closed")
+        .order("title"),
+    ]);
+
+  return (
+    <TaskTimeEntries
+      taskId={taskId}
+      clientId={clientId}
+      clients={allClients ?? []}
+      tasks={openTasks ?? []}
+      entries={timeEntries ?? []}
+    />
+  );
+}
+
+async function CommentsPanel({
+  taskId,
+  currentUserId,
+}: {
+  taskId: string;
+  currentUserId: string;
+}) {
+  const supabase = await createClient();
+  const { data: comments } = await supabase
+    .from("comments")
+    .select("id, body, author_role, author_id, created_at")
+    .eq("task_id", taskId)
+    .order("created_at", { ascending: true });
+
+  return (
+    <CommentThread
+      taskId={taskId}
+      currentUserId={currentUserId}
+      comments={comments ?? []}
+    />
+  );
+}
+
+// ─── Skeleton fallbacks ────────────────────────────────────────────────────────
+
+function AttachmentsSkeleton() {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+        <div className="h-6 w-20 rounded bg-muted/40 animate-pulse" />
+      </div>
+      <div className="h-12 rounded-md border border-dashed border-border bg-muted/10 animate-pulse" />
+    </div>
+  );
+}
+
+function TimeEntriesSkeleton() {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+        <div className="h-6 w-24 rounded bg-muted/40 animate-pulse" />
+      </div>
+      <div className="h-20 rounded-md border border-dashed border-border bg-muted/10 animate-pulse" />
+    </div>
+  );
+}
+
+function CommentsSkeleton() {
+  return (
+    <div className="space-y-3">
+      <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+      <div className="divide-y divide-border rounded-md border border-border">
+        {[1, 2].map((i) => (
+          <div key={i} className="flex gap-3 px-3 py-3">
+            <div className="h-7 w-7 shrink-0 rounded-full bg-muted animate-pulse" />
+            <div className="flex-1 space-y-1.5">
+              <div className="h-2.5 w-32 rounded bg-muted animate-pulse" />
+              <div className="h-3.5 w-full rounded bg-muted/60 animate-pulse" />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="h-20 rounded-md border border-border bg-muted/10 animate-pulse" />
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default async function TaskDetailPage({
   params,
@@ -65,54 +209,10 @@ export default async function TaskDetailPage({
 
   const taskId = task.id as string;
   const tenantId = profile?.tenant_id ?? client?.tenant_id ?? "";
-
-  const [
-    { data: attachments },
-    { data: comments },
-    { data: timeEntries },
-    { data: allClients },
-    { data: openTasks },
-  ] = await Promise.all([
-    supabase
-      .from("task_attachments")
-      .select("id, file_name, file_size, mime_type, public_url, created_at")
-      .eq("task_id", taskId)
-      .order("created_at", { ascending: true }),
-    supabase
-      .from("comments")
-      .select("id, body, author_role, author_id, created_at")
-      .eq("task_id", taskId)
-      .order("created_at", { ascending: true }),
-    supabase
-      .from("time_entries")
-      .select("id, description, entry_date, duration_hours, billable, billed, hourly_rate")
-      .eq("task_id", taskId)
-      .order("entry_date", { ascending: false }),
-    supabase
-      .from("clients")
-      .select("id, name, color, default_rate")
-      .eq("is_archived", false)
-      .order("name"),
-    supabase
-      .from("tasks")
-      .select("id, title, client_id")
-      .not("status", "eq", "closed")
-      .order("title"),
-  ]);
-
   const isClosed = task.status === "closed";
   const displayKey = client?.client_key
     ? `${client.client_key}-${task.task_number}`
     : null;
-
-  function formatDate(d: string | null) {
-    if (!d) return "—";
-    return new Date(d).toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-  }
 
   return (
     <>
@@ -213,32 +313,24 @@ export default async function TaskDetailPage({
 
           <Separator />
 
-          {/* Attachments */}
-          <AttachmentsList
-            taskId={taskId}
-            tenantId={tenantId}
-            attachments={attachments ?? []}
-          />
+          {/* Attachments — streamed */}
+          <Suspense fallback={<AttachmentsSkeleton />}>
+            <AttachmentsPanel taskId={taskId} tenantId={tenantId} />
+          </Suspense>
 
           <Separator />
 
-          {/* Time entries */}
-          <TaskTimeEntries
-            taskId={taskId}
-            clientId={client?.id ?? ""}
-            clients={allClients ?? []}
-            tasks={openTasks ?? []}
-            entries={timeEntries ?? []}
-          />
+          {/* Time entries — streamed */}
+          <Suspense fallback={<TimeEntriesSkeleton />}>
+            <TimeEntriesPanel taskId={taskId} clientId={client?.id ?? ""} />
+          </Suspense>
 
           <Separator />
 
-          {/* Comments */}
-          <CommentThread
-            taskId={taskId}
-            currentUserId={user.id}
-            comments={comments ?? []}
-          />
+          {/* Comments — streamed */}
+          <Suspense fallback={<CommentsSkeleton />}>
+            <CommentsPanel taskId={taskId} currentUserId={user.id} />
+          </Suspense>
         </div>
       </PageContainer>
     </>

--- a/app/(admin)/tasks/loading.tsx
+++ b/app/(admin)/tasks/loading.tsx
@@ -1,0 +1,47 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-6">
+        <div className="h-4 w-32 rounded bg-muted animate-pulse" />
+        <div className="h-7 w-20 rounded bg-muted/50 animate-pulse" />
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-6 space-y-4">
+        {/* Filter row */}
+        <div className="flex items-center gap-3">
+          <div className="h-7 w-48 rounded bg-muted/40 animate-pulse" />
+          <div className="h-7 w-64 rounded bg-muted/40 animate-pulse" />
+        </div>
+
+        {/* Table */}
+        <div className="rounded-md border border-border overflow-hidden">
+          {/* thead */}
+          <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-4">
+            <div className="h-2.5 w-12 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 flex-1 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+          </div>
+          {/* tbody rows */}
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 h-11 border-b border-border last:border-0 px-4"
+            >
+              <div className="h-4 w-12 rounded bg-muted/60 animate-pulse font-mono" />
+              <div className="h-3.5 flex-1 rounded bg-muted/50 animate-pulse" />
+              <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+              <div className="h-5 w-16 rounded-full bg-muted/40 animate-pulse" />
+              <div className="h-5 w-16 rounded-full bg-muted/40 animate-pulse" />
+              <div className="h-3 w-16 rounded bg-muted/40 animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/tasks/TaskListView.tsx
+++ b/components/tasks/TaskListView.tsx
@@ -21,7 +21,7 @@ function taskHref(task: Task) {
 
 function formatDate(d: string | null) {
   if (!d) return "—";
-  return new Date(d).toLocaleDateString(undefined, {
+  return new Date(d).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",

--- a/components/tasks/TaskStatusControl.tsx
+++ b/components/tasks/TaskStatusControl.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useOptimistic, useTransition } from "react";
 import { updateTaskStatusAction } from "@/app/actions/tasks";
 import { Button } from "@/components/ui/button";
 import { TaskStatusBadge } from "./TaskStatusBadge";
@@ -18,17 +18,19 @@ interface TaskStatusControlProps {
 
 export function TaskStatusControl({ taskId, currentStatus }: TaskStatusControlProps) {
   const [isPending, startTransition] = useTransition();
+  const [optimisticStatus, setOptimisticStatus] = useOptimistic(currentStatus);
 
   function setStatus(status: string) {
     startTransition(async () => {
+      setOptimisticStatus(status);
       await updateTaskStatusAction(taskId, status);
     });
   }
 
   return (
     <div className="flex items-center gap-2 flex-wrap">
-      <TaskStatusBadge status={currentStatus} />
-      {STATUSES.filter((s) => s.value !== currentStatus && currentStatus !== "closed").map((s) => (
+      <TaskStatusBadge status={optimisticStatus} />
+      {STATUSES.filter((s) => s.value !== optimisticStatus && optimisticStatus !== "closed").map((s) => (
         <Button
           key={s.value}
           variant="outline"
@@ -40,7 +42,7 @@ export function TaskStatusControl({ taskId, currentStatus }: TaskStatusControlPr
           {s.label}
         </Button>
       ))}
-      {currentStatus === "closed" && (
+      {optimisticStatus === "closed" && (
         <Button
           variant="outline"
           size="sm"


### PR DESCRIPTION
Closes #12

## Summary

- **`loading.tsx` for `/tasks`** — skeleton table (header + 8 rows) appears immediately on navigation, eliminating the blank content flash
- **`loading.tsx` for `/tasks/[taskId]`** — full-page skeleton (meta panel, editors, section placeholders) replaces the ~1s blank screen during task navigation
- **Suspense streaming on task detail** — core shell (title, meta panel, Milkdown editors) renders after 2 queries; attachments, time entries, and comments each stream in independently via async Server Component wrappers + `<Suspense>` — mirrors the existing `ClientTable` pattern in `clients/page.tsx`
- **`useOptimistic` in `TaskStatusControl`** — status badge updates instantly on click (<16ms); rolls back automatically if the server action fails
- **Hydration fix** — `toLocaleDateString(undefined)` → `toLocaleDateString("en-US")` in `TaskListView` (CLAUDE.md convention)

## Test plan

- [ ] Navigate to `/tasks` — skeleton table visible while list loads
- [ ] Navigate to any task — meta panel + editor skeletons appear immediately, then attachments/time/comments stream in
- [ ] Click a status button on a task — badge changes instantly without waiting for the server round-trip
- [ ] `npm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)