### PR TITLE
feat: Phase 6a — client portal

### DIFF
--- a/app/(admin)/clients/[clientId]/page.tsx
+++ b/app/(admin)/clients/[clientId]/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { TopBar } from "@/components/layout/TopBar";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { ArchiveClientButton } from "@/components/clients/ArchiveClientButton";
+import { PortalAccessSection } from "@/components/portal/PortalAccessSection";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
@@ -27,11 +28,14 @@ export default async function ClientDetailPage({
   const { clientId } = await params;
   const supabase = await createClient();
 
-  const { data: client, error } = await supabase
-    .from("clients")
-    .select("*")
-    .eq("id", clientId)
-    .single();
+  const [{ data: client, error }, { data: portalAccess }] = await Promise.all([
+    supabase.from("clients").select("*").eq("id", clientId).single(),
+    supabase
+      .from("client_portal_access")
+      .select("accepted_at")
+      .eq("client_id", clientId)
+      .maybeSingle(),
+  ]);
 
   if (error || !client) notFound();
 
@@ -132,6 +136,16 @@ export default async function ClientDetailPage({
               </div>
             </>
           )}
+
+          <Separator />
+
+          {/* Client portal access */}
+          <PortalAccessSection
+            clientId={client.id}
+            clientEmail={client.email}
+            hasAccess={!!portalAccess}
+            acceptedAt={portalAccess?.accepted_at ?? null}
+          />
 
           <Separator />
 

--- a/app/actions/comments.ts
+++ b/app/actions/comments.ts
@@ -43,18 +43,34 @@ export async function createCommentAction(
   const body = (formData.get("body") as string)?.trim();
   if (!body) return { error: "Comment cannot be empty." };
 
-  const { error } = await supabase.from("comments").insert({
-    tenant_id: profile.tenant_id,
-    task_id: taskId,
-    author_id: user.id,
-    author_role: profile.role,
-    body,
-  });
+  const { data: inserted, error } = await supabase
+    .from("comments")
+    .insert({
+      tenant_id: profile.tenant_id,
+      task_id: taskId,
+      author_id: user.id,
+      author_role: profile.role,
+      body,
+    })
+    .select("id")
+    .single();
 
   if (error) return { error: error.message };
 
   const slug = await getTaskSlug(supabase, taskId);
   revalidatePath(`/tasks/${slug}`);
+
+  const tenantSlug = user.app_metadata?.tenant_slug as string | undefined;
+  if (tenantSlug) revalidatePath(`/portal/${tenantSlug}/tasks/${taskId}`);
+
+  if (profile.role === "client" && inserted?.id) {
+    fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/email/comment`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ commentId: inserted.id }),
+    }).catch(() => {});
+  }
+
   return {};
 }
 
@@ -79,5 +95,9 @@ export async function deleteCommentAction(
 
   const slug = await getTaskSlug(supabase, taskId);
   revalidatePath(`/tasks/${slug}`);
+
+  const tenantSlug = user.app_metadata?.tenant_slug as string | undefined;
+  if (tenantSlug) revalidatePath(`/portal/${tenantSlug}/tasks/${taskId}`);
+
   return {};
 }

--- a/app/actions/portal.ts
+++ b/app/actions/portal.ts
@@ -1,0 +1,41 @@
+"use server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export async function inviteClientToPortalAction(
+  clientId: string,
+  _prev: { error?: string; success?: boolean } | null,
+  formData: FormData
+): Promise<{ error?: string; success?: boolean }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized." };
+
+  const email = (formData.get("email") as string)?.trim();
+  if (!email) return { error: "Email is required." };
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("tenant_id, role")
+    .eq("id", user.id)
+    .single();
+  if (!profile || profile.role !== "admin") return { error: "Unauthorized." };
+
+  const { data: client } = await supabase
+    .from("clients")
+    .select("id")
+    .eq("id", clientId)
+    .single();
+  if (!client) return { error: "Client not found." };
+
+  const admin = createAdminClient();
+  const { error } = await admin.auth.admin.inviteUserByEmail(email, {
+    data: { role: "client", tenant_id: profile.tenant_id, client_id: clientId },
+    redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback`,
+  });
+
+  if (error) return { error: error.message };
+  return { success: true };
+}

--- a/app/api/email/comment/route.ts
+++ b/app/api/email/comment/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function POST(request: NextRequest) {
+  const { commentId } = await request.json();
+
+  if (!commentId) {
+    return NextResponse.json({ error: "Missing commentId" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+
+  const { data: comment, error: commentError } = await supabase
+    .from("comments")
+    .select("id, body, tenant_id, tasks(id, title)")
+    .eq("id", commentId)
+    .single();
+
+  if (commentError || !comment) {
+    return NextResponse.json({ error: "Comment not found" }, { status: 404 });
+  }
+
+  const task = comment.tasks as unknown as { id: string; title: string } | null;
+  if (!task) {
+    return NextResponse.json({ error: "Task not found" }, { status: 404 });
+  }
+
+  const { data: settings } = await supabase
+    .from("tenant_settings")
+    .select("email, business_name")
+    .eq("tenant_id", comment.tenant_id)
+    .single();
+
+  if (!settings?.email) {
+    return NextResponse.json({ skipped: true });
+  }
+
+  const subject = `New comment on: ${task.title}`;
+
+  const html = `
+    <p>A client left a new comment on task <strong>${escapeHtml(task.title)}</strong>:</p>
+    <blockquote style="background:#f6f8fa;padding:12px;border-radius:6px;border-left:3px solid #0969da;white-space:pre-line">${escapeHtml(comment.body)}</blockquote>
+    <p>— ${escapeHtml(settings.business_name ?? "TaskFlow")}</p>
+  `;
+
+  const { data: sendData, error: sendError } = await resend.emails.send({
+    from: `${settings.business_name ?? "TaskFlow"} <noreply@${process.env.RESEND_DOMAIN ?? "taskflow.dev"}>`,
+    to: settings.email,
+    subject,
+    html,
+  });
+
+  await supabase.from("email_log").insert({
+    tenant_id: comment.tenant_id,
+    to_email: settings.email,
+    subject,
+    type: "comment",
+    related_id: commentId,
+    resend_id: sendData?.id ?? null,
+    status: sendError ? "failed" : "sent",
+    error_message: sendError?.message ?? null,
+  });
+
+  if (sendError) {
+    return NextResponse.json({ error: sendError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ sent: true });
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -41,13 +41,60 @@ export async function GET(request: NextRequest) {
   // Check whether this user already has a profile (returning user)
   const { data: existingProfile } = await supabase
     .from("profiles")
-    .select("id")
+    .select("id, role")
     .eq("id", user.id)
     .single();
 
   if (existingProfile) {
-    // Returning user — proceed normally
+    // Returning user — redirect based on role
+    if (existingProfile.role === "client") {
+      const tenantSlug = user.app_metadata?.tenant_slug as string | undefined;
+      if (tenantSlug) return NextResponse.redirect(`${origin}/portal/${tenantSlug}`);
+      return NextResponse.redirect(`${origin}/auth/login?error=auth_callback_error`);
+    }
     return NextResponse.redirect(`${origin}${next}`);
+  }
+
+  // ── Client invite acceptance ──────────────────────────────────────────────
+  if (user.user_metadata?.role === "client") {
+    const tenantId = user.user_metadata.tenant_id as string;
+    const clientId = user.user_metadata.client_id as string;
+    if (!tenantId || !clientId) {
+      await supabase.auth.signOut();
+      return NextResponse.redirect(`${origin}/auth/login?error=auth_callback_error`);
+    }
+    const admin = createAdminClient();
+    const { data: tenant } = await admin
+      .from("tenants")
+      .select("slug")
+      .eq("id", tenantId)
+      .single();
+    if (!tenant) {
+      await supabase.auth.signOut();
+      return NextResponse.redirect(`${origin}/auth/login?error=auth_callback_error`);
+    }
+    await admin.from("profiles").insert({
+      id: user.id,
+      tenant_id: tenantId,
+      role: "client",
+      full_name:
+        user.user_metadata.full_name ?? user.email?.split("@")[0] ?? "Client",
+    });
+    await admin.from("client_portal_access").insert({
+      tenant_id: tenantId,
+      client_id: clientId,
+      user_id: user.id,
+      invited_at: new Date().toISOString(),
+      accepted_at: new Date().toISOString(),
+    });
+    await admin.auth.admin.updateUserById(user.id, {
+      app_metadata: {
+        role: "client",
+        tenant_id: tenantId,
+        tenant_slug: tenant.slug,
+      },
+    });
+    return NextResponse.redirect(`${origin}/portal/${tenant.slug}`);
   }
 
   // ── First-time OAuth sign-in ──────────────────────────────────────────────

--- a/app/portal/[tenantSlug]/layout.tsx
+++ b/app/portal/[tenantSlug]/layout.tsx
@@ -1,11 +1,59 @@
-export default function PortalLayout({
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { PortalSignOutButton } from "@/components/portal/PortalSignOutButton";
+
+export default async function PortalLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: Promise<{ tenantSlug: string }>;
 }) {
+  const { tenantSlug } = await params;
+
+  const admin = createAdminClient();
+  const { data: tenant } = await admin
+    .from("tenants")
+    .select("id, slug")
+    .eq("slug", tenantSlug)
+    .single();
+
+  if (!tenant) redirect("/auth/login?error=auth_callback_error");
+
+  const { data: settings } = await admin
+    .from("tenant_settings")
+    .select("business_name")
+    .eq("tenant_id", tenant.id)
+    .single();
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Auth check: must be a client belonging to this tenant
+  if (
+    !user ||
+    user.app_metadata?.role !== "client" ||
+    user.app_metadata?.tenant_id !== tenant.id
+  ) {
+    redirect(`/portal/${tenantSlug}/login`);
+  }
+
+  const businessName = settings?.business_name ?? tenantSlug;
+
   return (
     <div className="min-h-screen bg-background">
-      {children}
+      <header className="border-b border-border bg-background/95 backdrop-blur sticky top-0 z-10">
+        <div className="mx-auto max-w-4xl px-6 h-12 flex items-center justify-between">
+          <span className="text-sm font-semibold text-foreground">
+            {businessName}
+          </span>
+          <PortalSignOutButton tenantSlug={tenantSlug} />
+        </div>
+      </header>
+      <main className="mx-auto max-w-4xl px-6 py-8">{children}</main>
     </div>
   );
 }

--- a/app/portal/[tenantSlug]/login/page.tsx
+++ b/app/portal/[tenantSlug]/login/page.tsx
@@ -1,15 +1,40 @@
-export default function PortalLoginPage({
+import { createAdminClient } from "@/lib/supabase/admin";
+import { PortalLoginForm } from "@/components/portal/PortalLoginForm";
+
+export default async function PortalLoginPage({
   params,
 }: {
-  params: { tenantSlug: string };
+  params: Promise<{ tenantSlug: string }>;
 }) {
+  const { tenantSlug } = await params;
+
+  const admin = createAdminClient();
+  const { data: tenant } = await admin
+    .from("tenants")
+    .select("id")
+    .eq("slug", tenantSlug)
+    .single();
+
+  let businessName = tenantSlug;
+  if (tenant) {
+    const { data: settings } = await admin
+      .from("tenant_settings")
+      .select("business_name")
+      .eq("tenant_id", tenant.id)
+      .single();
+    if (settings?.business_name) businessName = settings.business_name;
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="w-full max-w-sm space-y-4 px-4">
-        <h1 className="text-xl font-semibold">Client Portal</h1>
-        <p className="text-sm text-muted-foreground">
-          Sign in to {params.tenantSlug} — coming in Phase 6a.
-        </p>
+      <div className="w-full max-w-sm space-y-6 px-4">
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold">{businessName}</h1>
+          <p className="text-sm text-muted-foreground">
+            Sign in to your client portal
+          </p>
+        </div>
+        <PortalLoginForm tenantSlug={tenantSlug} />
       </div>
     </div>
   );

--- a/app/portal/[tenantSlug]/page.tsx
+++ b/app/portal/[tenantSlug]/page.tsx
@@ -1,13 +1,103 @@
-export default function PortalDashboardPage({
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { TaskStatusBadge, TaskPriorityBadge } from "@/components/tasks/TaskStatusBadge";
+
+function formatDate(d: string | null) {
+  if (!d) return null;
+  return new Date(d).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default async function PortalDashboardPage({
   params,
 }: {
-  params: { tenantSlug: string };
+  params: Promise<{ tenantSlug: string }>;
 }) {
+  const { tenantSlug } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Get the client_id for this portal user
+  const { data: access } = await supabase
+    .from("client_portal_access")
+    .select("client_id")
+    .eq("user_id", user!.id)
+    .single();
+
+  const clientId = access?.client_id;
+
+  // Fetch tasks for this client (RLS client_tasks_select enforces access)
+  const { data: tasks } = clientId
+    ? await supabase
+        .from("tasks")
+        .select("id, title, status, priority, due_date, created_at")
+        .eq("client_id", clientId)
+        .order("created_at", { ascending: false })
+    : { data: [] };
+
+  // Fetch welcome message if no tasks
+  let welcomeMessage: string | null = null;
+  if (!tasks?.length) {
+    const admin = createAdminClient();
+    const tenantId = user!.app_metadata?.tenant_id as string | undefined;
+    if (tenantId) {
+      const { data: settings } = await admin
+        .from("tenant_settings")
+        .select("portal_welcome_message")
+        .eq("tenant_id", tenantId)
+        .single();
+      welcomeMessage = settings?.portal_welcome_message ?? null;
+    }
+  }
+
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <p className="text-sm text-muted-foreground">
-        Portal for <strong>{params.tenantSlug}</strong> — coming in Phase 6a.
-      </p>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-lg font-semibold">Your Tasks</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          View and track the tasks your consultant is working on.
+        </p>
+      </div>
+
+      {!tasks?.length ? (
+        <div className="rounded-md border border-dashed border-border p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            {welcomeMessage ?? "No tasks yet. Your consultant will add tasks here."}
+          </p>
+        </div>
+      ) : (
+        <div className="divide-y divide-border rounded-md border border-border">
+          {tasks.map((task) => (
+            <Link
+              key={task.id}
+              href={`/portal/${tenantSlug}/tasks/${task.id}`}
+              className="flex items-center gap-4 px-4 py-3 hover:bg-muted/40 transition-colors"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-foreground truncate">
+                  {task.title}
+                </p>
+                {task.due_date && (
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Due {formatDate(task.due_date)}
+                  </p>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <TaskPriorityBadge priority={task.priority} />
+                <TaskStatusBadge status={task.status} />
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/portal/[tenantSlug]/tasks/[taskId]/page.tsx
+++ b/app/portal/[tenantSlug]/tasks/[taskId]/page.tsx
@@ -1,13 +1,131 @@
-export default function PortalTaskPage({
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { Separator } from "@/components/ui/separator";
+import { TaskStatusBadge, TaskPriorityBadge } from "@/components/tasks/TaskStatusBadge";
+import { CommentThread } from "@/components/comments/CommentThread";
+import { PortalReadOnlyEditor } from "@/components/portal/PortalTaskContent";
+
+function formatDate(d: string | null) {
+  if (!d) return "—";
+  return new Date(d).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default async function PortalTaskPage({
   params,
 }: {
-  params: { tenantSlug: string; taskId: string };
+  params: Promise<{ tenantSlug: string; taskId: string }>;
 }) {
+  const { tenantSlug, taskId } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) notFound();
+
+  // Fetch task — RLS client_tasks_select enforces access
+  const { data: task, error } = await supabase
+    .from("tasks")
+    .select("id, title, status, priority, due_date, description, resolution_notes, created_at, closed_at")
+    .eq("id", taskId)
+    .single();
+
+  if (error || !task) notFound();
+
+  // Fetch comments — RLS client_comments_select enforces access
+  const { data: comments } = await supabase
+    .from("comments")
+    .select("id, body, author_role, author_id, created_at")
+    .eq("task_id", taskId)
+    .order("created_at", { ascending: true });
+
+  const isClosed = task.status === "closed";
+
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <p className="text-sm text-muted-foreground">
-        Task {params.taskId} — coming in Phase 6a.
-      </p>
+    <div className="space-y-6">
+      {/* Back link */}
+      <div>
+        <a
+          href={`/portal/${tenantSlug}`}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← Back to tasks
+        </a>
+      </div>
+
+      {/* Title */}
+      <div>
+        <h1 className="text-lg font-semibold text-foreground">{task.title}</h1>
+        <div className="flex items-center gap-2 mt-2">
+          <TaskStatusBadge status={task.status} />
+          <TaskPriorityBadge priority={task.priority} />
+        </div>
+      </div>
+
+      {/* Meta */}
+      <div className="grid grid-cols-2 gap-4 rounded-md border border-border bg-muted/20 px-5 py-4 text-sm">
+        <div className="flex gap-3">
+          <span className="w-24 shrink-0 text-muted-foreground">Due date</span>
+          <span
+            className={
+              task.due_date && !isClosed && new Date(task.due_date) < new Date()
+                ? "text-red-600 dark:text-red-400 font-medium"
+                : "text-foreground"
+            }
+          >
+            {formatDate(task.due_date)}
+          </span>
+        </div>
+        <div className="flex gap-3">
+          <span className="w-24 shrink-0 text-muted-foreground">Created</span>
+          <span className="text-foreground">{formatDate(task.created_at)}</span>
+        </div>
+        {task.closed_at && (
+          <div className="flex gap-3">
+            <span className="w-24 shrink-0 text-muted-foreground">Closed</span>
+            <span className="text-foreground">{formatDate(task.closed_at)}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Description */}
+      {task.description && (
+        <>
+          <Separator />
+          <div className="space-y-2">
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Description
+            </h2>
+            <PortalReadOnlyEditor value={task.description} />
+          </div>
+        </>
+      )}
+
+      {/* Resolution notes */}
+      {task.resolution_notes && (
+        <>
+          <Separator />
+          <div className="space-y-2">
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Resolution Notes
+            </h2>
+            <PortalReadOnlyEditor value={task.resolution_notes} />
+          </div>
+        </>
+      )}
+
+      <Separator />
+
+      {/* Comments */}
+      <CommentThread
+        taskId={taskId}
+        currentUserId={user.id}
+        comments={comments ?? []}
+      />
     </div>
   );
 }

--- a/components/portal/PortalAccessSection.tsx
+++ b/components/portal/PortalAccessSection.tsx
@@ -1,0 +1,85 @@
+"use client";
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { inviteClientToPortalAction } from "@/app/actions/portal";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { CheckCircle2 } from "lucide-react";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" className="h-7 text-xs" disabled={pending}>
+      {pending ? "Sending…" : "Send invite"}
+    </Button>
+  );
+}
+
+export function PortalAccessSection({
+  clientId,
+  clientEmail,
+  hasAccess,
+  acceptedAt,
+}: {
+  clientId: string;
+  clientEmail: string | null;
+  hasAccess: boolean;
+  acceptedAt: string | null;
+}) {
+  const boundAction = inviteClientToPortalAction.bind(null, clientId);
+  const [state, formAction] = useActionState(boundAction, null);
+
+  return (
+    <div>
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Client Portal Access
+      </h2>
+
+      {hasAccess ? (
+        <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+          <CheckCircle2 className="h-4 w-4" />
+          <span>
+            Portal access granted
+            {acceptedAt
+              ? ` · accepted ${new Date(acceptedAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`
+              : ""}
+          </span>
+        </div>
+      ) : (
+        <>
+          <p className="text-sm text-muted-foreground mb-3">
+            Invite this client to access their portal. They&apos;ll receive an email with a
+            magic link to set up their account.
+          </p>
+          {state?.success ? (
+            <p className="text-sm text-emerald-600 dark:text-emerald-400">
+              Invite sent successfully.
+            </p>
+          ) : (
+            <form action={formAction} className="flex items-end gap-2 max-w-sm">
+              <div className="flex-1 space-y-1">
+                <Label htmlFor="portal-invite-email" className="text-xs">
+                  Email address
+                </Label>
+                <Input
+                  id="portal-invite-email"
+                  name="email"
+                  type="email"
+                  defaultValue={clientEmail ?? ""}
+                  placeholder="client@example.com"
+                  className="h-7 text-xs"
+                  required
+                />
+              </div>
+              <SubmitButton />
+            </form>
+          )}
+          {state?.error && (
+            <p className="mt-1.5 text-xs text-destructive">{state.error}</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/portal/PortalLoginForm.tsx
+++ b/components/portal/PortalLoginForm.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function PortalLoginForm({ tenantSlug }: { tenantSlug: string }) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const supabase = createClient();
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (signInError) {
+      setError(signInError.message);
+      setLoading(false);
+      return;
+    }
+    router.push(`/portal/${tenantSlug}`);
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          type="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="password">Password</Label>
+        <Input
+          id="password"
+          type="password"
+          autoComplete="current-password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? "Signing in…" : "Sign in"}
+      </Button>
+    </form>
+  );
+}

--- a/components/portal/PortalSignOutButton.tsx
+++ b/components/portal/PortalSignOutButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+
+export function PortalSignOutButton({ tenantSlug }: { tenantSlug: string }) {
+  const router = useRouter();
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push(`/portal/${tenantSlug}/login`);
+    router.refresh();
+  }
+  return (
+    <Button variant="ghost" size="sm" className="text-xs" onClick={handleSignOut}>
+      Sign out
+    </Button>
+  );
+}

--- a/components/portal/PortalTaskContent.tsx
+++ b/components/portal/PortalTaskContent.tsx
@@ -1,0 +1,11 @@
+"use client";
+import dynamic from "next/dynamic";
+
+const MilkdownEditor = dynamic(
+  () => import("@/components/editor/MilkdownEditor"),
+  { ssr: false }
+);
+
+export function PortalReadOnlyEditor({ value }: { value: string }) {
+  return <MilkdownEditor value={value} readOnly minHeight="80px" />;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -68,6 +68,12 @@ export async function proxy(request: NextRequest) {
         new URL(`/portal/${tenantSlug}/login`, request.url)
       );
     }
+    // Redirect client to their own tenant if they navigate to another
+    const urlSlug = pathname.split("/")[2] ?? "";
+    const userSlug = user.app_metadata?.tenant_slug as string | undefined;
+    if (userSlug && userSlug !== urlSlug) {
+      return NextResponse.redirect(new URL(`/portal/${userSlug}`, request.url));
+    }
     return supabaseResponse;
   }
 

--- a/supabase/migrations/20260303000006_client_portal.sql
+++ b/supabase/migrations/20260303000006_client_portal.sql
@@ -1,0 +1,78 @@
+-- ── client_portal_access ──────────────────────────────────────────────────────
+CREATE TABLE client_portal_access (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id   UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  client_id   UUID NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+  user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  invited_at  TIMESTAMPTZ,
+  accepted_at TIMESTAMPTZ,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, client_id, user_id)
+);
+ALTER TABLE client_portal_access ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "admin_portal_access_all" ON client_portal_access
+  FOR ALL TO authenticated
+  USING (auth_role() = 'admin' AND tenant_id = auth_tenant_id())
+  WITH CHECK (auth_role() = 'admin' AND tenant_id = auth_tenant_id());
+
+CREATE POLICY "client_portal_access_select_own" ON client_portal_access
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+-- tasks: client SELECT
+CREATE POLICY "client_tasks_select" ON tasks
+  FOR SELECT TO authenticated
+  USING (
+    auth_role() = 'client'
+    AND client_id IN (
+      SELECT client_id FROM client_portal_access WHERE user_id = auth.uid()
+    )
+  );
+
+-- task_attachments: client SELECT
+CREATE POLICY "client_attachments_select" ON task_attachments
+  FOR SELECT TO authenticated
+  USING (
+    auth_role() = 'client'
+    AND task_id IN (
+      SELECT t.id FROM tasks t
+      INNER JOIN client_portal_access cpa ON cpa.client_id = t.client_id
+      WHERE cpa.user_id = auth.uid()
+    )
+  );
+
+-- Drop Phase 3 placeholder, add granular comment policies
+DROP POLICY IF EXISTS "client_comments_own" ON comments;
+
+CREATE POLICY "client_comments_select" ON comments
+  FOR SELECT TO authenticated
+  USING (
+    auth_role() = 'client'
+    AND task_id IN (
+      SELECT t.id FROM tasks t
+      INNER JOIN client_portal_access cpa ON cpa.client_id = t.client_id
+      WHERE cpa.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "client_comments_insert" ON comments
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    auth_role() = 'client'
+    AND author_id = auth.uid()
+    AND tenant_id = auth_tenant_id()
+    AND task_id IN (
+      SELECT t.id FROM tasks t
+      INNER JOIN client_portal_access cpa ON cpa.client_id = t.client_id
+      WHERE cpa.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "client_comments_update_own" ON comments
+  FOR UPDATE TO authenticated
+  USING (auth_role() = 'client' AND author_id = auth.uid() AND tenant_id = auth_tenant_id());
+
+CREATE POLICY "client_comments_delete_own" ON comments
+  FOR DELETE TO authenticated
+  USING (auth_role() = 'client' AND author_id = auth.uid() AND tenant_id = auth_tenant_id());


### PR DESCRIPTION
## Summary

- Adds `client_portal_access` table (migration `20260303000006_client_portal.sql`) with RLS policies granting clients read access to their tasks, attachments, and comments
- Admin can invite clients to the portal from the client detail page (`PortalAccessSection`)
- Auth callback handles invite acceptance: creates profile + portal access record, sets `app_metadata.role/tenant_slug`, redirects to portal
- Portal layout with auth guard, branded header (business name from `tenant_settings`), and sign-out button
- Portal dashboard lists client's tasks with status/priority badges and links
- Portal task detail shows read-only Milkdown editors for description + resolution notes, plus the shared `CommentThread`
- Clients posting comments trigger a fire-and-forget email to the consultant via `/api/email/comment`
- `proxy.ts` validates tenant slug and redirects clients to their own portal if they navigate elsewhere

## Test plan

- [ ] Admin invites a client from `/clients/[id]` — invite email sent via Supabase
- [ ] Client clicks invite link → profile + portal access created → lands on `/portal/[slug]`
- [ ] Portal task list shows only tasks for that client
- [ ] Portal task detail renders description/resolution notes read-only + comment thread
- [ ] Client posts comment → consultant receives email notification
- [ ] Navigating to another tenant's portal redirects to the client's own portal
- [ ] `npm run build` passes with no errors

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)