### PR TITLE
feat: Phase 6b/6c — portal magic link, Google OAuth, and account management

### DIFF
--- a/app/actions/clients.ts
+++ b/app/actions/clients.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 
 interface ClientFields {
   name: string;
@@ -134,12 +135,36 @@ export async function updateClientAction(
     if (keyError) return { error: keyError };
   }
 
+  // Fetch current email before update to detect changes
+  const { data: existing } = await supabase
+    .from("clients")
+    .select("email")
+    .eq("id", clientId)
+    .single();
+
   const { error } = await supabase
     .from("clients")
     .update(buildClientPayload(fields))
     .eq("id", clientId);
 
   if (error) return { error: error.message };
+
+  // Sync auth user email if it changed and client has portal access
+  const newEmail = fields.email.trim();
+  if (existing && existing.email !== newEmail && newEmail) {
+    const admin = createAdminClient();
+    const { data: access } = await admin
+      .from("client_portal_access")
+      .select("user_id")
+      .eq("client_id", clientId)
+      .single();
+    if (access?.user_id) {
+      await admin.auth.admin.updateUserById(access.user_id as string, {
+        email: newEmail,
+        email_confirm: true,
+      });
+    }
+  }
 
   revalidatePath(`/clients/${clientId}`);
   revalidatePath("/clients");

--- a/app/actions/portal.ts
+++ b/app/actions/portal.ts
@@ -104,3 +104,95 @@ export async function finalizeInviteAction(): Promise<{
 
   return { slug: tenant.slug };
 }
+
+export async function sendPortalSignInLinkAction(
+  clientId: string,
+  _prev: { error?: string; success?: boolean } | null
+): Promise<{ error?: string; success?: boolean }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized." };
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("tenant_id, role")
+    .eq("id", user.id)
+    .single();
+  if (!profile || profile.role !== "admin") return { error: "Unauthorized." };
+
+  // Get client email and portal access
+  const { data: client } = await supabase
+    .from("clients")
+    .select("email")
+    .eq("id", clientId)
+    .single();
+  if (!client?.email) return { error: "Client email not found." };
+
+  const admin = createAdminClient();
+  const { data: access } = await admin
+    .from("client_portal_access")
+    .select("user_id")
+    .eq("client_id", clientId)
+    .eq("tenant_id", profile.tenant_id)
+    .single();
+  if (!access) return { error: "Client does not have portal access." };
+
+  const { data: tenant } = await admin
+    .from("tenants")
+    .select("slug")
+    .eq("id", profile.tenant_id)
+    .single();
+  if (!tenant) return { error: "Tenant not found." };
+
+  const { error } = await supabase.auth.signInWithOtp({
+    email: client.email,
+    options: {
+      emailRedirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback?next=/portal/${tenant.slug}`,
+    },
+  });
+
+  if (error) return { error: error.message };
+  return { success: true };
+}
+
+export async function revokePortalAccessAction(
+  clientId: string
+): Promise<{ error?: string; success?: boolean }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized." };
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("tenant_id, role")
+    .eq("id", user.id)
+    .single();
+  if (!profile || profile.role !== "admin") return { error: "Unauthorized." };
+
+  const admin = createAdminClient();
+  const { data: access } = await admin
+    .from("client_portal_access")
+    .select("user_id")
+    .eq("client_id", clientId)
+    .eq("tenant_id", profile.tenant_id)
+    .single();
+  if (!access) return { error: "No portal access found." };
+
+  const userId = access.user_id as string;
+
+  await admin.from("profiles").delete().eq("id", userId);
+  await admin
+    .from("client_portal_access")
+    .delete()
+    .eq("client_id", clientId)
+    .eq("tenant_id", profile.tenant_id);
+  await admin.auth.admin.deleteUser(userId);
+
+  const { revalidatePath } = await import("next/cache");
+  revalidatePath(`/clients/${clientId}`);
+  return { success: true };
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -97,6 +97,66 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${origin}/portal/${tenant.slug}`);
   }
 
+  // ── Portal Google OAuth first-time sign-in ──────────────────────────────
+  // No profile + not an email invite + next is a portal URL.
+  // Match the user's email to an existing clients record to authorize access.
+  if (next.startsWith("/portal/")) {
+    const portalSlug = next.split("/")[2];
+    const admin = createAdminClient();
+
+    const { data: tenant } = await admin
+      .from("tenants")
+      .select("id, slug")
+      .eq("slug", portalSlug)
+      .single();
+    if (!tenant) {
+      await supabase.auth.signOut();
+      return NextResponse.redirect(
+        `${origin}/portal/${portalSlug}/login?error=auth_callback_error`
+      );
+    }
+
+    const { data: client } = await admin
+      .from("clients")
+      .select("id")
+      .eq("email", user.email)
+      .eq("tenant_id", tenant.id)
+      .single();
+    if (!client) {
+      await supabase.auth.signOut();
+      return NextResponse.redirect(
+        `${origin}/portal/${portalSlug}/login?error=not_invited`
+      );
+    }
+
+    const displayName =
+      user.user_metadata?.full_name ??
+      user.user_metadata?.name ??
+      user.email?.split("@")[0] ??
+      "Client";
+
+    await admin.from("profiles").insert({
+      id: user.id,
+      tenant_id: tenant.id,
+      role: "client",
+      full_name: displayName,
+    });
+    await admin.from("client_portal_access").insert({
+      tenant_id: tenant.id,
+      client_id: client.id,
+      user_id: user.id,
+      accepted_at: new Date().toISOString(),
+    });
+    await admin.auth.admin.updateUserById(user.id, {
+      app_metadata: {
+        role: "client",
+        tenant_id: tenant.id,
+        tenant_slug: tenant.slug,
+      },
+    });
+    return NextResponse.redirect(`${origin}/portal/${tenant.slug}`);
+  }
+
   // ── First-time OAuth sign-in ──────────────────────────────────────────────
   // No profile means this is a brand-new user (e.g. Google OAuth first login).
   // Create a tenant + profile + settings, then set app_metadata.

--- a/app/portal/[tenantSlug]/login/page.tsx
+++ b/app/portal/[tenantSlug]/login/page.tsx
@@ -3,10 +3,12 @@ import { PortalLoginForm } from "@/components/portal/PortalLoginForm";
 
 export default async function PortalLoginPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ tenantSlug: string }>;
+  searchParams: Promise<{ error?: string }>;
 }) {
-  const { tenantSlug } = await params;
+  const [{ tenantSlug }, { error }] = await Promise.all([params, searchParams]);
 
   const admin = createAdminClient();
   const { data: tenant } = await admin
@@ -34,7 +36,7 @@ export default async function PortalLoginPage({
             Sign in to your client portal
           </p>
         </div>
-        <PortalLoginForm tenantSlug={tenantSlug} />
+        <PortalLoginForm tenantSlug={tenantSlug} initialError={error} />
       </div>
     </div>
   );

--- a/components/portal/PortalAccessSection.tsx
+++ b/components/portal/PortalAccessSection.tsx
@@ -1,7 +1,11 @@
 "use client";
-import { useActionState } from "react";
+import { useActionState, useTransition, useState } from "react";
 import { useFormStatus } from "react-dom";
-import { inviteClientToPortalAction } from "@/app/actions/portal";
+import {
+  inviteClientToPortalAction,
+  sendPortalSignInLinkAction,
+  revokePortalAccessAction,
+} from "@/app/actions/portal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -27,8 +31,20 @@ export function PortalAccessSection({
   hasAccess: boolean;
   acceptedAt: string | null;
 }) {
-  const boundAction = inviteClientToPortalAction.bind(null, clientId);
-  const [state, formAction] = useActionState(boundAction, null);
+  const boundInvite = inviteClientToPortalAction.bind(null, clientId);
+  const [inviteState, inviteFormAction] = useActionState(boundInvite, null);
+
+  const boundSendLink = sendPortalSignInLinkAction.bind(null, clientId);
+  const [linkState, sendLinkAction] = useActionState(boundSendLink, null);
+
+  const [isPending, startTransition] = useTransition();
+  const [confirmRevoke, setConfirmRevoke] = useState(false);
+
+  function handleRevoke() {
+    startTransition(async () => {
+      await revokePortalAccessAction(clientId);
+    });
+  }
 
   return (
     <div>
@@ -37,14 +53,75 @@ export function PortalAccessSection({
       </h2>
 
       {hasAccess ? (
-        <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
-          <CheckCircle2 className="h-4 w-4" />
-          <span>
-            Portal access granted
-            {acceptedAt
-              ? ` · accepted ${new Date(acceptedAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`
-              : ""}
-          </span>
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+            <CheckCircle2 className="h-4 w-4 shrink-0" />
+            <span>
+              Portal access granted
+              {acceptedAt
+                ? ` · accepted ${new Date(acceptedAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`
+                : ""}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {/* Send sign-in link */}
+            {linkState?.success ? (
+              <span className="text-xs text-emerald-600 dark:text-emerald-400">
+                Sign-in link sent.
+              </span>
+            ) : (
+              <form action={sendLinkAction}>
+                <Button
+                  type="submit"
+                  size="sm"
+                  variant="outline"
+                  className="h-7 text-xs"
+                  disabled={isPending}
+                >
+                  Send sign-in link
+                </Button>
+              </form>
+            )}
+
+            {/* Revoke access */}
+            {confirmRevoke ? (
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">Revoke access?</span>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  className="h-7 text-xs"
+                  disabled={isPending}
+                  onClick={handleRevoke}
+                >
+                  {isPending ? "Revoking…" : "Yes, revoke"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-xs"
+                  disabled={isPending}
+                  onClick={() => setConfirmRevoke(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs text-destructive hover:text-destructive"
+                onClick={() => setConfirmRevoke(true)}
+              >
+                Revoke access
+              </Button>
+            )}
+          </div>
+
+          {linkState?.error && (
+            <p className="text-xs text-destructive">{linkState.error}</p>
+          )}
         </div>
       ) : (
         <>
@@ -52,12 +129,12 @@ export function PortalAccessSection({
             Invite this client to access their portal. They&apos;ll receive an email with a
             magic link to set up their account.
           </p>
-          {state?.success ? (
+          {inviteState?.success ? (
             <p className="text-sm text-emerald-600 dark:text-emerald-400">
               Invite sent successfully.
             </p>
           ) : (
-            <form action={formAction} className="flex items-end gap-2 max-w-sm">
+            <form action={inviteFormAction} className="flex items-end gap-2 max-w-sm">
               <div className="flex-1 space-y-1">
                 <Label htmlFor="portal-invite-email" className="text-xs">
                   Email address
@@ -75,8 +152,8 @@ export function PortalAccessSection({
               <SubmitButton />
             </form>
           )}
-          {state?.error && (
-            <p className="mt-1.5 text-xs text-destructive">{state.error}</p>
+          {inviteState?.error && (
+            <p className="mt-1.5 text-xs text-destructive">{inviteState.error}</p>
           )}
         </>
       )}

--- a/components/portal/PortalLoginForm.tsx
+++ b/components/portal/PortalLoginForm.tsx
@@ -5,13 +5,58 @@ import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 
-export function PortalLoginForm({ tenantSlug }: { tenantSlug: string }) {
+function errorMessage(code: string | undefined): string | null {
+  switch (code) {
+    case "auth_callback_error":
+      return "Authentication failed. Please try again.";
+    case "not_invited":
+      return "Your Google account is not linked to a portal invitation.";
+    default:
+      return null;
+  }
+}
+
+// Google icon — inline SVG to avoid an extra dependency
+function GoogleIcon() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}
+
+export function PortalLoginForm({
+  tenantSlug,
+  initialError,
+}: {
+  tenantSlug: string;
+  initialError?: string;
+}) {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(errorMessage(initialError));
   const [loading, setLoading] = useState(false);
+  const [magicLinkLoading, setMagicLinkLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
+  const [magicLinkSent, setMagicLinkSent] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -31,34 +76,128 @@ export function PortalLoginForm({ tenantSlug }: { tenantSlug: string }) {
     router.refresh();
   }
 
+  async function handleMagicLink() {
+    if (!email) {
+      setError("Enter your email above first.");
+      return;
+    }
+    setError(null);
+    setMagicLinkLoading(true);
+    const supabase = createClient();
+    const { error: otpError } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback?next=/portal/${tenantSlug}`,
+      },
+    });
+    if (otpError) {
+      setError(otpError.message);
+    } else {
+      setMagicLinkSent(true);
+    }
+    setMagicLinkLoading(false);
+  }
+
+  async function handleGoogleSignIn() {
+    setError(null);
+    setGoogleLoading(true);
+    const supabase = createClient();
+    const { error: oauthError } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback?next=/portal/${tenantSlug}`,
+      },
+    });
+    if (oauthError) {
+      setError(oauthError.message);
+      setGoogleLoading(false);
+    }
+    // On success the browser redirects — no further action needed here
+  }
+
+  const busy = loading || magicLinkLoading || googleLoading;
+
+  if (magicLinkSent) {
+    return (
+      <Alert>
+        <AlertDescription>
+          Check your email for a sign-in link.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-1.5">
-        <Label htmlFor="email">Email</Label>
-        <Input
-          id="email"
-          type="email"
-          autoComplete="email"
-          required
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-      </div>
-      <div className="space-y-1.5">
-        <Label htmlFor="password">Password</Label>
-        <Input
-          id="password"
-          type="password"
-          autoComplete="current-password"
-          required
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-      </div>
-      {error && <p className="text-xs text-destructive">{error}</p>}
-      <Button type="submit" className="w-full" disabled={loading}>
-        {loading ? "Signing in…" : "Sign in"}
+    <div className="space-y-4">
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Google OAuth */}
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        disabled={busy}
+        onClick={handleGoogleSignIn}
+      >
+        <GoogleIcon />
+        <span className="ml-2">
+          {googleLoading ? "Redirecting…" : "Continue with Google"}
+        </span>
       </Button>
-    </form>
+
+      {/* Divider */}
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t border-border" />
+        </div>
+        <div className="relative flex justify-center text-xs">
+          <span className="bg-background px-2 text-muted-foreground">or</span>
+        </div>
+      </div>
+
+      {/* Email / password */}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <Button type="submit" className="w-full" disabled={busy}>
+          {loading ? "Signing in…" : "Sign in"}
+        </Button>
+      </form>
+
+      {/* Magic link */}
+      <Button
+        type="button"
+        variant="ghost"
+        className="w-full text-muted-foreground"
+        disabled={busy}
+        onClick={handleMagicLink}
+      >
+        {magicLinkLoading ? "Sending…" : "Email me a sign-in link"}
+      </Button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Phase 6b**: Portal login now supports magic link ("Email me a sign-in link") — Supabase sends the email, redirects back to the correct tenant portal via `?next=` param
- **Phase 6c**: Portal login now supports Google OAuth — first-time sign-in matches the user's email to an existing `clients` record; returns a `not_invited` error if no match
- **Account management**: Admin can send a sign-in link or fully revoke a client's portal access from the client detail page
- **Email sync**: Editing a client's email in the admin app automatically syncs the Supabase Auth user's email if the client has an active portal account

## Changes

- `components/portal/PortalLoginForm.tsx` — Google OAuth + magic link buttons, error handling for callback codes
- `app/portal/[tenantSlug]/login/page.tsx` — passes `searchParams.error` to form
- `app/auth/callback/route.ts` — new case for portal-initiated OAuth first-time sign-in
- `app/actions/portal.ts` — `sendPortalSignInLinkAction`, `revokePortalAccessAction`
- `app/actions/clients.ts` — syncs auth user email on client email change
- `components/portal/PortalAccessSection.tsx` — "Send sign-in link" + two-step "Revoke access" UI

## Test plan

- [ ] Visit `/portal/[slug]/login` — verify Google, magic link, and password options appear
- [ ] Magic link: enter email, click "Email me a sign-in link" — confirm email arrives and link lands on portal
- [ ] Google OAuth: sign in with a Google account whose email matches a client — should land on portal
- [ ] Google OAuth with unknown email — should show "not linked to a portal invitation" error
- [ ] Admin: open a client with portal access → click "Send sign-in link" — confirm email arrives
- [ ] Admin: click "Revoke access" → confirm → verify user deleted in Supabase, re-invite works
- [ ] Admin: edit a client's email → verify auth user email updates in Supabase dashboard
- [ ] `npm run build` passes ✅

Closes #3
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)