### PR TITLE
feat: Phase 7 — settings page and reports

### DIFF
--- a/app/(admin)/reports/page.tsx
+++ b/app/(admin)/reports/page.tsx
@@ -1,12 +1,393 @@
+import { redirect } from "next/navigation";
 import { TopBar } from "@/components/layout/TopBar";
 import { PageContainer } from "@/components/layout/PageContainer";
+import { Separator } from "@/components/ui/separator";
+import { createClient } from "@/lib/supabase/server";
 
-export default function ReportsPage() {
+interface SearchParams {
+  start?: string;
+  end?: string;
+}
+
+function fmt(amount: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+  }).format(amount);
+}
+
+function fmtHours(hours: number) {
+  return `${hours.toFixed(2)} h`;
+}
+
+export default async function ReportsPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || user.app_metadata?.role !== "admin") redirect("/auth/login");
+
+  const sp = await searchParams;
+
+  // Default date range: current calendar year
+  const now = new Date();
+  const defaultStart = `${now.getFullYear()}-01-01`;
+  const defaultEnd = `${now.getFullYear()}-12-31`;
+  const start = sp.start || defaultStart;
+  const end = sp.end || defaultEnd;
+
+  // Fetch all data in parallel
+  const [
+    { data: clients },
+    { data: timeEntries },
+    { data: invoices },
+    { data: payments },
+    { data: unbilledEntries },
+  ] = await Promise.all([
+    supabase.from("clients").select("id, name, color").eq("archived", false),
+    supabase
+      .from("time_entries")
+      .select("client_id, duration_hours, billable, entry_date")
+      .gte("entry_date", start)
+      .lte("entry_date", end),
+    supabase
+      .from("invoices")
+      .select("id, client_id, total, status, issue_date")
+      .gte("issue_date", start)
+      .lte("issue_date", end)
+      .neq("status", "draft"),
+    supabase
+      .from("payments")
+      .select("invoice_id, amount, payment_date")
+      .gte("payment_date", start)
+      .lte("payment_date", end),
+    supabase
+      .from("time_entries")
+      .select("client_id, duration_hours, hourly_rate")
+      .eq("billable", true)
+      .eq("billed", false)
+      .is("invoice_id", null),
+  ]);
+
+  // Build lookup maps
+  const clientMap = new Map(
+    (clients ?? []).map((c) => [c.id, { name: c.name, color: c.color }])
+  );
+
+  // Paid invoice IDs set (for cross-referencing payments)
+  const invoiceMap = new Map((invoices ?? []).map((i) => [i.id, i]));
+
+  // Revenue by client
+  type ClientRow = {
+    name: string;
+    color: string;
+    totalHours: number;
+    billableHours: number;
+    invoicedAmount: number;
+    paidAmount: number;
+  };
+  const clientStats = new Map<string, ClientRow>();
+
+  for (const c of clients ?? []) {
+    clientStats.set(c.id, {
+      name: c.name,
+      color: c.color ?? "#0969da",
+      totalHours: 0,
+      billableHours: 0,
+      invoicedAmount: 0,
+      paidAmount: 0,
+    });
+  }
+
+  for (const te of timeEntries ?? []) {
+    const row = clientStats.get(te.client_id);
+    if (!row) continue;
+    row.totalHours += Number(te.duration_hours ?? 0);
+    if (te.billable) row.billableHours += Number(te.duration_hours ?? 0);
+  }
+
+  for (const inv of invoices ?? []) {
+    const row = clientStats.get(inv.client_id);
+    if (!row) continue;
+    row.invoicedAmount += Number(inv.total ?? 0);
+  }
+
+  for (const p of payments ?? []) {
+    const inv = invoiceMap.get(p.invoice_id);
+    if (!inv) continue;
+    const row = clientStats.get(inv.client_id);
+    if (!row) continue;
+    row.paidAmount += Number(p.amount ?? 0);
+  }
+
+  const clientRows = [...clientStats.values()].filter(
+    (r) => r.totalHours > 0 || r.invoicedAmount > 0
+  );
+  clientRows.sort((a, b) => b.invoicedAmount - a.invoicedAmount);
+
+  // Revenue by month
+  type MonthRow = { month: string; hours: number; invoiced: number; paid: number };
+  const monthMap = new Map<string, MonthRow>();
+
+  for (const te of timeEntries ?? []) {
+    const month = te.entry_date.slice(0, 7); // "YYYY-MM"
+    if (!monthMap.has(month)) monthMap.set(month, { month, hours: 0, invoiced: 0, paid: 0 });
+    monthMap.get(month)!.hours += Number(te.duration_hours ?? 0);
+  }
+
+  for (const inv of invoices ?? []) {
+    const month = inv.issue_date.slice(0, 7);
+    if (!monthMap.has(month)) monthMap.set(month, { month, hours: 0, invoiced: 0, paid: 0 });
+    monthMap.get(month)!.invoiced += Number(inv.total ?? 0);
+  }
+
+  for (const p of payments ?? []) {
+    const month = p.payment_date.slice(0, 7);
+    if (!monthMap.has(month)) monthMap.set(month, { month, hours: 0, invoiced: 0, paid: 0 });
+    monthMap.get(month)!.paid += Number(p.amount ?? 0);
+  }
+
+  const monthRows = [...monthMap.values()].sort((a, b) => a.month.localeCompare(b.month));
+
+  // Unbilled hours by client
+  type UnbilledRow = { clientId: string; name: string; color: string; hours: number; estimated: number };
+  const unbilledMap = new Map<string, UnbilledRow>();
+
+  for (const te of unbilledEntries ?? []) {
+    const client = clientMap.get(te.client_id);
+    if (!unbilledMap.has(te.client_id)) {
+      unbilledMap.set(te.client_id, {
+        clientId: te.client_id,
+        name: client?.name ?? "Unknown",
+        color: client?.color ?? "#0969da",
+        hours: 0,
+        estimated: 0,
+      });
+    }
+    const row = unbilledMap.get(te.client_id)!;
+    const h = Number(te.duration_hours ?? 0);
+    row.hours += h;
+    row.estimated += h * Number(te.hourly_rate ?? 0);
+  }
+
+  const unbilledRows = [...unbilledMap.values()].filter((r) => r.hours > 0);
+  unbilledRows.sort((a, b) => b.hours - a.hours);
+
+  const totalUnbilledHours = unbilledRows.reduce((s, r) => s + r.hours, 0);
+  const totalUnbilledEstimated = unbilledRows.reduce((s, r) => s + r.estimated, 0);
+
   return (
     <>
-      <TopBar title="Reports" />
+      <TopBar title="Reports" description="Revenue and time tracking summary." />
       <PageContainer>
-        <p className="text-sm text-muted-foreground">Coming soon — Phase 7.</p>
+        <div className="space-y-10">
+
+          {/* Date range filter */}
+          <form method="GET" className="flex items-end gap-3">
+            <div className="space-y-1">
+              <label htmlFor="start" className="text-xs font-medium text-muted-foreground">
+                From
+              </label>
+              <input
+                id="start"
+                name="start"
+                type="date"
+                defaultValue={start}
+                className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="end" className="text-xs font-medium text-muted-foreground">
+                To
+              </label>
+              <input
+                id="end"
+                name="end"
+                type="date"
+                defaultValue={end}
+                className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+            <button
+              type="submit"
+              className="h-9 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Apply
+            </button>
+          </form>
+
+          <Separator />
+
+          {/* Revenue by client */}
+          <section>
+            <h2 className="text-base font-semibold mb-4">Revenue by client</h2>
+            {clientRows.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No data for this period.</p>
+            ) : (
+              <div className="overflow-x-auto rounded-md border border-border">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-muted/40 text-left text-xs font-medium text-muted-foreground">
+                      <th className="px-4 py-2.5">Client</th>
+                      <th className="px-4 py-2.5 text-right">Total hours</th>
+                      <th className="px-4 py-2.5 text-right">Billable hours</th>
+                      <th className="px-4 py-2.5 text-right">Invoiced</th>
+                      <th className="px-4 py-2.5 text-right">Paid</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {clientRows.map((row) => (
+                      <tr key={row.name} className="hover:bg-muted/30">
+                        <td className="px-4 py-2.5">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="h-2.5 w-2.5 rounded-full flex-shrink-0"
+                              style={{ backgroundColor: row.color }}
+                            />
+                            {row.name}
+                          </div>
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums">
+                          {fmtHours(row.totalHours)}
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums">
+                          {fmtHours(row.billableHours)}
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums font-medium">
+                          {fmt(row.invoicedAmount)}
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums text-green-700 dark:text-green-400">
+                          {fmt(row.paidAmount)}
+                        </td>
+                      </tr>
+                    ))}
+                    {/* Totals */}
+                    <tr className="bg-muted/40 font-medium">
+                      <td className="px-4 py-2.5 text-xs text-muted-foreground">Total</td>
+                      <td className="px-4 py-2.5 text-right tabular-nums text-xs">
+                        {fmtHours(clientRows.reduce((s, r) => s + r.totalHours, 0))}
+                      </td>
+                      <td className="px-4 py-2.5 text-right tabular-nums text-xs">
+                        {fmtHours(clientRows.reduce((s, r) => s + r.billableHours, 0))}
+                      </td>
+                      <td className="px-4 py-2.5 text-right tabular-nums text-xs">
+                        {fmt(clientRows.reduce((s, r) => s + r.invoicedAmount, 0))}
+                      </td>
+                      <td className="px-4 py-2.5 text-right tabular-nums text-xs text-green-700 dark:text-green-400">
+                        {fmt(clientRows.reduce((s, r) => s + r.paidAmount, 0))}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+
+          <Separator />
+
+          {/* Revenue by month */}
+          <section>
+            <h2 className="text-base font-semibold mb-4">Revenue by month</h2>
+            {monthRows.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No data for this period.</p>
+            ) : (
+              <div className="overflow-x-auto rounded-md border border-border">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-muted/40 text-left text-xs font-medium text-muted-foreground">
+                      <th className="px-4 py-2.5">Month</th>
+                      <th className="px-4 py-2.5 text-right">Hours logged</th>
+                      <th className="px-4 py-2.5 text-right">Invoiced</th>
+                      <th className="px-4 py-2.5 text-right">Paid</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {monthRows.map((row) => (
+                      <tr key={row.month} className="hover:bg-muted/30">
+                        <td className="px-4 py-2.5 font-medium tabular-nums">
+                          {new Date(row.month + "-15").toLocaleDateString("en-US", {
+                            month: "long",
+                            year: "numeric",
+                          })}
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums">
+                          {fmtHours(row.hours)}
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums">
+                          {fmt(row.invoiced)}
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums text-green-700 dark:text-green-400">
+                          {fmt(row.paid)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+
+          <Separator />
+
+          {/* Unbilled hours */}
+          <section>
+            <h2 className="text-base font-semibold mb-1">Unbilled hours</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              Billable time entries not yet included in an invoice — across all dates.
+            </p>
+            {unbilledRows.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No unbilled hours.</p>
+            ) : (
+              <div className="overflow-x-auto rounded-md border border-border">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-muted/40 text-left text-xs font-medium text-muted-foreground">
+                      <th className="px-4 py-2.5">Client</th>
+                      <th className="px-4 py-2.5 text-right">Unbilled hours</th>
+                      <th className="px-4 py-2.5 text-right">Estimated value</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {unbilledRows.map((row) => (
+                      <tr key={row.clientId} className="hover:bg-muted/30">
+                        <td className="px-4 py-2.5">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="h-2.5 w-2.5 rounded-full flex-shrink-0"
+                              style={{ backgroundColor: row.color }}
+                            />
+                            {row.name}
+                          </div>
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums font-medium">
+                          {fmtHours(row.hours)}
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums text-muted-foreground">
+                          {row.estimated > 0 ? fmt(row.estimated) : "—"}
+                        </td>
+                      </tr>
+                    ))}
+                    <tr className="bg-muted/40 font-medium">
+                      <td className="px-4 py-2.5 text-xs text-muted-foreground">Total</td>
+                      <td className="px-4 py-2.5 text-right tabular-nums text-xs">
+                        {fmtHours(totalUnbilledHours)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right tabular-nums text-xs text-muted-foreground">
+                        {totalUnbilledEstimated > 0 ? fmt(totalUnbilledEstimated) : "—"}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+
+        </div>
       </PageContainer>
     </>
   );

--- a/app/(admin)/settings/page.tsx
+++ b/app/(admin)/settings/page.tsx
@@ -1,12 +1,113 @@
+import { redirect } from "next/navigation";
 import { TopBar } from "@/components/layout/TopBar";
 import { PageContainer } from "@/components/layout/PageContainer";
+import { Separator } from "@/components/ui/separator";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { BusinessInfoForm } from "@/components/settings/BusinessInfoForm";
+import { BrandingForm } from "@/components/settings/BrandingForm";
+import { InvoiceSettingsForm } from "@/components/settings/InvoiceSettingsForm";
+import { EmailTemplatesForm } from "@/components/settings/EmailTemplatesForm";
+import { TenantSlugForm } from "@/components/settings/TenantSlugForm";
 
-export default function SettingsPage() {
+export default async function SettingsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || user.app_metadata?.role !== "admin") redirect("/auth/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("tenant_id")
+    .eq("id", user.id)
+    .single();
+  if (!profile) redirect("/auth/login");
+
+  const tenantId = profile.tenant_id as string;
+
+  const [{ data: settings }, { data: tenant }] = await Promise.all([
+    supabase
+      .from("tenant_settings")
+      .select("*")
+      .eq("tenant_id", tenantId)
+      .single(),
+    createAdminClient().from("tenants").select("slug").eq("id", tenantId).single(),
+  ]);
+
+  if (!settings) {
+    return (
+      <>
+        <TopBar title="Settings" />
+        <PageContainer>
+          <p className="text-sm text-muted-foreground">Settings not found. Please contact support.</p>
+        </PageContainer>
+      </>
+    );
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+
   return (
     <>
-      <TopBar title="Settings" />
+      <TopBar title="Settings" description="Manage your account and workspace preferences." />
       <PageContainer>
-        <p className="text-sm text-muted-foreground">Coming soon — Phase 7.</p>
+        <div className="space-y-10 max-w-3xl">
+
+          {/* Business info */}
+          <section>
+            <h2 className="text-base font-semibold">Business information</h2>
+            <p className="text-sm text-muted-foreground mt-0.5 mb-4">
+              Used on invoices and as your business identity.
+            </p>
+            <BusinessInfoForm settings={settings} />
+          </section>
+
+          <Separator />
+
+          {/* Branding */}
+          <section>
+            <h2 className="text-base font-semibold">Branding</h2>
+            <p className="text-sm text-muted-foreground mt-0.5 mb-4">
+              Logo and colors shown in the client portal.
+            </p>
+            <BrandingForm tenantId={tenantId} settings={settings} />
+          </section>
+
+          <Separator />
+
+          {/* Invoice settings */}
+          <section>
+            <h2 className="text-base font-semibold">Invoice settings</h2>
+            <p className="text-sm text-muted-foreground mt-0.5 mb-4">
+              Defaults applied when creating new invoices.
+            </p>
+            <InvoiceSettingsForm settings={settings} />
+          </section>
+
+          <Separator />
+
+          {/* Email templates */}
+          <section>
+            <h2 className="text-base font-semibold">Email templates</h2>
+            <p className="text-sm text-muted-foreground mt-0.5 mb-4">
+              Customize outgoing notification emails.
+            </p>
+            <EmailTemplatesForm settings={settings} />
+          </section>
+
+          <Separator />
+
+          {/* Tenant slug */}
+          <section>
+            <h2 className="text-base font-semibold">Portal URL</h2>
+            <p className="text-sm text-muted-foreground mt-0.5 mb-4">
+              The URL your clients use to access their portal.
+            </p>
+            <TenantSlugForm slug={tenant?.slug ?? ""} appUrl={appUrl} />
+          </section>
+
+        </div>
       </PageContainer>
     </>
   );

--- a/app/actions/settings.ts
+++ b/app/actions/settings.ts
@@ -1,0 +1,207 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+type ActionResult = { error?: string };
+
+async function getAdminCtx() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || user.app_metadata?.role !== "admin") return null;
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("tenant_id")
+    .eq("id", user.id)
+    .single();
+  if (!profile) return null;
+
+  return { supabase, tenantId: profile.tenant_id as string };
+}
+
+export async function updateBusinessInfoAction(
+  _prev: ActionResult | null,
+  formData: FormData
+): Promise<ActionResult> {
+  const ctx = await getAdminCtx();
+  if (!ctx) return { error: "Unauthorized." };
+
+  const get = (k: string) => (formData.get(k) as string) ?? "";
+
+  const { error } = await ctx.supabase
+    .from("tenant_settings")
+    .update({
+      business_name: get("business_name").trim() || null,
+      address_line1: get("address_line1").trim() || null,
+      address_line2: get("address_line2").trim() || null,
+      city: get("city").trim() || null,
+      state: get("state").trim() || null,
+      postal_code: get("postal_code").trim() || null,
+      country: get("country").trim() || "US",
+      email: get("email").trim() || null,
+      phone: get("phone").trim() || null,
+    })
+    .eq("tenant_id", ctx.tenantId);
+
+  if (error) return { error: error.message };
+  revalidatePath("/settings");
+  return {};
+}
+
+export async function updateBrandingAction(
+  _prev: ActionResult | null,
+  formData: FormData
+): Promise<ActionResult> {
+  const ctx = await getAdminCtx();
+  if (!ctx) return { error: "Unauthorized." };
+
+  const logo_url = (formData.get("logo_url") as string) ?? "";
+  const primary_color = (formData.get("primary_color") as string) ?? "#0969da";
+  const accent_color = (formData.get("accent_color") as string) ?? "#0550ae";
+  const portal_welcome_message = (formData.get("portal_welcome_message") as string) ?? "";
+
+  const update: Record<string, unknown> = {
+    primary_color: primary_color || "#0969da",
+    accent_color: accent_color || "#0550ae",
+    portal_welcome_message: portal_welcome_message.trim() || null,
+  };
+  if (logo_url.trim()) {
+    update.logo_url = logo_url.trim();
+  }
+
+  const { error } = await ctx.supabase
+    .from("tenant_settings")
+    .update(update)
+    .eq("tenant_id", ctx.tenantId);
+
+  if (error) return { error: error.message };
+  revalidatePath("/settings");
+  return {};
+}
+
+export async function updateInvoiceSettingsAction(
+  _prev: ActionResult | null,
+  formData: FormData
+): Promise<ActionResult> {
+  const ctx = await getAdminCtx();
+  if (!ctx) return { error: "Unauthorized." };
+
+  const prefix = (formData.get("invoice_number_prefix") as string) ?? "INV-";
+  const nextStr = (formData.get("invoice_number_next") as string) ?? "1001";
+  const termsStr = (formData.get("default_payment_terms") as string) ?? "30";
+  const currency = (formData.get("default_currency") as string) ?? "USD";
+  const taxRateStr = (formData.get("default_tax_rate") as string) ?? "0";
+  const taxLabel = (formData.get("tax_label") as string) ?? "Tax";
+  const paymentMethodsJson = (formData.get("payment_method_options") as string) ?? "[]";
+
+  const invoiceNext = parseInt(nextStr);
+  if (isNaN(invoiceNext) || invoiceNext < 1)
+    return { error: "Invoice number must be a positive integer." };
+
+  const terms = parseInt(termsStr);
+  if (isNaN(terms) || terms < 0)
+    return { error: "Payment terms must be a non-negative integer." };
+
+  const taxRate = parseFloat(taxRateStr);
+  if (isNaN(taxRate) || taxRate < 0 || taxRate > 100)
+    return { error: "Tax rate must be between 0 and 100." };
+
+  let paymentMethods: string[];
+  try {
+    paymentMethods = JSON.parse(paymentMethodsJson);
+    if (!Array.isArray(paymentMethods)) throw new Error();
+  } catch {
+    return { error: "Invalid payment methods." };
+  }
+
+  const { error } = await ctx.supabase
+    .from("tenant_settings")
+    .update({
+      invoice_number_prefix: prefix.trim() || "INV-",
+      invoice_number_next: invoiceNext,
+      default_payment_terms: terms,
+      default_currency: currency || "USD",
+      default_tax_rate: taxRate / 100, // stored as 0–1 decimal
+      tax_label: taxLabel.trim() || "Tax",
+      payment_method_options: paymentMethods,
+    })
+    .eq("tenant_id", ctx.tenantId);
+
+  if (error) return { error: error.message };
+  revalidatePath("/settings");
+  return {};
+}
+
+export async function updateEmailTemplatesAction(
+  _prev: ActionResult | null,
+  formData: FormData
+): Promise<ActionResult> {
+  const ctx = await getAdminCtx();
+  if (!ctx) return { error: "Unauthorized." };
+
+  const get = (k: string) => (formData.get(k) as string) ?? "";
+
+  const { error } = await ctx.supabase
+    .from("tenant_settings")
+    .update({
+      email_sender_name: get("email_sender_name").trim() || null,
+      email_reply_to: get("email_reply_to").trim() || null,
+      email_task_closed_subject: get("email_task_closed_subject").trim() || null,
+      email_task_closed_body: get("email_task_closed_body").trim() || null,
+      email_invoice_subject: get("email_invoice_subject").trim() || null,
+      email_invoice_body: get("email_invoice_body").trim() || null,
+      email_comment_subject: get("email_comment_subject").trim() || null,
+      email_comment_body: get("email_comment_body").trim() || null,
+      email_signature: get("email_signature").trim() || null,
+    })
+    .eq("tenant_id", ctx.tenantId);
+
+  if (error) return { error: error.message };
+  revalidatePath("/settings");
+  return {};
+}
+
+export async function updateTenantSlugAction(
+  _prev: ActionResult | null,
+  formData: FormData
+): Promise<ActionResult> {
+  const ctx = await getAdminCtx();
+  if (!ctx) return { error: "Unauthorized." };
+
+  const slug = ((formData.get("slug") as string) ?? "").trim().toLowerCase();
+  if (!slug) return { error: "Slug is required." };
+  if (!/^[a-z0-9-]+$/.test(slug))
+    return { error: "Slug may only contain lowercase letters, numbers, and hyphens." };
+
+  const admin = createAdminClient();
+
+  // Check current slug
+  const { data: tenant } = await admin
+    .from("tenants")
+    .select("slug")
+    .eq("id", ctx.tenantId)
+    .single();
+  if (!tenant) return { error: "Tenant not found." };
+  if (tenant.slug === slug) return {}; // no change
+
+  // Uniqueness check
+  const { data: existing } = await admin
+    .from("tenants")
+    .select("id")
+    .eq("slug", slug)
+    .maybeSingle();
+  if (existing) return { error: "This slug is already taken. Please choose another." };
+
+  const { error } = await admin
+    .from("tenants")
+    .update({ slug })
+    .eq("id", ctx.tenantId);
+
+  if (error) return { error: error.message };
+  revalidatePath("/settings");
+  return {};
+}

--- a/components/settings/BrandingForm.tsx
+++ b/components/settings/BrandingForm.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { updateBrandingAction } from "@/app/actions/settings";
+
+interface Props {
+  tenantId: string;
+  settings: {
+    logo_url?: string | null;
+    primary_color?: string | null;
+    accent_color?: string | null;
+    portal_welcome_message?: string | null;
+  };
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" disabled={pending}>
+      {pending ? "Saving…" : "Save"}
+    </Button>
+  );
+}
+
+function ColorPicker({
+  id,
+  name,
+  label,
+  defaultValue,
+}: {
+  id: string;
+  name: string;
+  label: string;
+  defaultValue: string;
+}) {
+  const [value, setValue] = useState(defaultValue);
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="h-8 w-10 cursor-pointer rounded border border-border bg-background p-0.5"
+        />
+        <Input
+          id={id}
+          name={name}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="#0969da"
+          className="w-32 font-mono text-sm"
+          maxLength={7}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function BrandingForm({ tenantId, settings }: Props) {
+  const [state, formAction] = useActionState(updateBrandingAction, null);
+  const [logoUrl, setLogoUrl] = useState(settings.logo_url ?? "");
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const ext = file.name.split(".").pop() ?? "png";
+    setUploading(true);
+    setUploadError(null);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch(
+        `/api/upload?path=tenant-${tenantId}/logo/logo.${ext}`,
+        { method: "POST", body: fd }
+      );
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Upload failed");
+      setLogoUrl(json.url);
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <form action={formAction} className="space-y-6 max-w-2xl">
+      {(state?.error || uploadError) && (
+        <Alert variant="destructive">
+          <AlertDescription>{state?.error ?? uploadError}</AlertDescription>
+        </Alert>
+      )}
+      {state && !state.error && (
+        <Alert>
+          <AlertDescription>Saved.</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Logo */}
+      <div className="space-y-2">
+        <Label>Logo</Label>
+        {logoUrl && (
+          <div className="mb-2 flex items-center gap-3">
+            <div className="relative h-12 w-auto min-w-[48px] overflow-hidden rounded border border-border bg-muted">
+              <Image
+                src={logoUrl}
+                alt="Logo"
+                width={120}
+                height={48}
+                className="h-12 w-auto object-contain"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground"
+              onClick={() => setLogoUrl("")}
+            >
+              Remove
+            </Button>
+          </div>
+        )}
+        <input type="hidden" name="logo_url" value={logoUrl} />
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={uploading}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            {uploading ? "Uploading…" : "Upload logo"}
+          </Button>
+          <span className="text-xs text-muted-foreground">PNG, JPG, SVG — max 20 MB</span>
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleLogoChange}
+        />
+      </div>
+
+      {/* Colors */}
+      <div className="grid grid-cols-2 gap-6">
+        <ColorPicker
+          id="primary_color"
+          name="primary_color"
+          label="Primary color"
+          defaultValue={settings.primary_color ?? "#0969da"}
+        />
+        <ColorPicker
+          id="accent_color"
+          name="accent_color"
+          label="Accent color"
+          defaultValue={settings.accent_color ?? "#0550ae"}
+        />
+      </div>
+
+      {/* Portal welcome message */}
+      <div className="space-y-1.5">
+        <Label htmlFor="portal_welcome_message">Portal welcome message</Label>
+        <Textarea
+          id="portal_welcome_message"
+          name="portal_welcome_message"
+          rows={3}
+          defaultValue={settings.portal_welcome_message ?? ""}
+          placeholder="Welcome to your client portal."
+        />
+        <p className="text-xs text-muted-foreground">
+          Shown at the top of the client portal dashboard.
+        </p>
+      </div>
+
+      <div className="pt-2">
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}

--- a/components/settings/BusinessInfoForm.tsx
+++ b/components/settings/BusinessInfoForm.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { updateBusinessInfoAction } from "@/app/actions/settings";
+
+interface Props {
+  settings: {
+    business_name?: string | null;
+    address_line1?: string | null;
+    address_line2?: string | null;
+    city?: string | null;
+    state?: string | null;
+    postal_code?: string | null;
+    country?: string | null;
+    email?: string | null;
+    phone?: string | null;
+  };
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" disabled={pending}>
+      {pending ? "Saving…" : "Save"}
+    </Button>
+  );
+}
+
+export function BusinessInfoForm({ settings }: Props) {
+  const [state, formAction] = useActionState(updateBusinessInfoAction, null);
+
+  return (
+    <form action={formAction} className="space-y-4 max-w-2xl">
+      {state?.error && (
+        <Alert variant="destructive">
+          <AlertDescription>{state.error}</AlertDescription>
+        </Alert>
+      )}
+      {state && !state.error && (
+        <Alert>
+          <AlertDescription>Saved.</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="col-span-2 space-y-1.5">
+          <Label htmlFor="business_name">Business name</Label>
+          <Input
+            id="business_name"
+            name="business_name"
+            defaultValue={settings.business_name ?? ""}
+            placeholder="Acme Consulting"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="email">Business email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            defaultValue={settings.email ?? ""}
+            placeholder="hello@example.com"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="phone">Phone</Label>
+          <Input
+            id="phone"
+            name="phone"
+            type="tel"
+            defaultValue={settings.phone ?? ""}
+            placeholder="+1 555 000 0000"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="address_line1">Address line 1</Label>
+        <Input
+          id="address_line1"
+          name="address_line1"
+          defaultValue={settings.address_line1 ?? ""}
+          placeholder="123 Main St"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="address_line2">Address line 2</Label>
+        <Input
+          id="address_line2"
+          name="address_line2"
+          defaultValue={settings.address_line2 ?? ""}
+          placeholder="Suite 100"
+        />
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="city">City</Label>
+          <Input
+            id="city"
+            name="city"
+            defaultValue={settings.city ?? ""}
+            placeholder="San Francisco"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="state">State / Province</Label>
+          <Input
+            id="state"
+            name="state"
+            defaultValue={settings.state ?? ""}
+            placeholder="CA"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="postal_code">Postal code</Label>
+          <Input
+            id="postal_code"
+            name="postal_code"
+            defaultValue={settings.postal_code ?? ""}
+            placeholder="94105"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5 max-w-xs">
+        <Label htmlFor="country">Country</Label>
+        <Input
+          id="country"
+          name="country"
+          defaultValue={settings.country ?? "US"}
+          placeholder="US"
+        />
+      </div>
+
+      <div className="pt-2">
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}

--- a/components/settings/EmailTemplatesForm.tsx
+++ b/components/settings/EmailTemplatesForm.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Separator } from "@/components/ui/separator";
+import { updateEmailTemplatesAction } from "@/app/actions/settings";
+
+interface Props {
+  settings: {
+    email_sender_name?: string | null;
+    email_reply_to?: string | null;
+    email_task_closed_subject?: string | null;
+    email_task_closed_body?: string | null;
+    email_invoice_subject?: string | null;
+    email_invoice_body?: string | null;
+    email_comment_subject?: string | null;
+    email_comment_body?: string | null;
+    email_signature?: string | null;
+  };
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" disabled={pending}>
+      {pending ? "Saving…" : "Save"}
+    </Button>
+  );
+}
+
+function TemplateGroup({
+  title,
+  subjectName,
+  bodyName,
+  subjectDefault,
+  bodyDefault,
+  subjectPlaceholder,
+  bodyPlaceholder,
+  variableHints,
+}: {
+  title: string;
+  subjectName: string;
+  bodyName: string;
+  subjectDefault: string;
+  bodyDefault: string;
+  subjectPlaceholder: string;
+  bodyPlaceholder: string;
+  variableHints: string;
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium">{title}</p>
+      <div className="space-y-1.5">
+        <Label htmlFor={subjectName}>Subject</Label>
+        <Input
+          id={subjectName}
+          name={subjectName}
+          defaultValue={subjectDefault}
+          placeholder={subjectPlaceholder}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor={bodyName}>Body</Label>
+        <Textarea
+          id={bodyName}
+          name={bodyName}
+          rows={5}
+          defaultValue={bodyDefault}
+          placeholder={bodyPlaceholder}
+        />
+        <p className="text-xs text-muted-foreground">
+          Available variables: {variableHints}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function EmailTemplatesForm({ settings }: Props) {
+  const [state, formAction] = useActionState(updateEmailTemplatesAction, null);
+
+  return (
+    <form action={formAction} className="space-y-6 max-w-2xl">
+      {state?.error && (
+        <Alert variant="destructive">
+          <AlertDescription>{state.error}</AlertDescription>
+        </Alert>
+      )}
+      {state && !state.error && (
+        <Alert>
+          <AlertDescription>Saved.</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Sender */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="email_sender_name">Sender name</Label>
+          <Input
+            id="email_sender_name"
+            name="email_sender_name"
+            defaultValue={settings.email_sender_name ?? ""}
+            placeholder="Your business name"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="email_reply_to">Reply-to address</Label>
+          <Input
+            id="email_reply_to"
+            name="email_reply_to"
+            type="email"
+            defaultValue={settings.email_reply_to ?? ""}
+            placeholder="hello@example.com"
+          />
+        </div>
+      </div>
+
+      <Separator />
+
+      <TemplateGroup
+        title="Task closed"
+        subjectName="email_task_closed_subject"
+        bodyName="email_task_closed_body"
+        subjectDefault={settings.email_task_closed_subject ?? ""}
+        bodyDefault={settings.email_task_closed_body ?? ""}
+        subjectPlaceholder="Your task has been completed"
+        bodyPlaceholder="Hi, your task '{{task_title}}' has been completed…"
+        variableHints="{{task_title}}, {{resolution_notes}}, {{portal_link}}"
+      />
+
+      <Separator />
+
+      <TemplateGroup
+        title="Invoice"
+        subjectName="email_invoice_subject"
+        bodyName="email_invoice_body"
+        subjectDefault={settings.email_invoice_subject ?? ""}
+        bodyDefault={settings.email_invoice_body ?? ""}
+        subjectPlaceholder="Invoice {{invoice_number}} from {{business_name}}"
+        bodyPlaceholder="Please find attached invoice {{invoice_number}}…"
+        variableHints="{{invoice_number}}, {{business_name}}, {{amount_due}}, {{due_date}}"
+      />
+
+      <Separator />
+
+      <TemplateGroup
+        title="Comment notification"
+        subjectName="email_comment_subject"
+        bodyName="email_comment_body"
+        subjectDefault={settings.email_comment_subject ?? ""}
+        bodyDefault={settings.email_comment_body ?? ""}
+        subjectPlaceholder="New comment on your task"
+        bodyPlaceholder="A new comment has been posted on task '{{task_title}}'…"
+        variableHints="{{task_title}}, {{comment_author}}, {{portal_link}}"
+      />
+
+      <Separator />
+
+      {/* Signature */}
+      <div className="space-y-1.5">
+        <Label htmlFor="email_signature">Email signature</Label>
+        <Textarea
+          id="email_signature"
+          name="email_signature"
+          rows={4}
+          defaultValue={settings.email_signature ?? ""}
+          placeholder="Best regards,&#10;Your Name"
+        />
+      </div>
+
+      <div className="pt-2">
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}

--- a/components/settings/InvoiceSettingsForm.tsx
+++ b/components/settings/InvoiceSettingsForm.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { updateInvoiceSettingsAction } from "@/app/actions/settings";
+
+interface Props {
+  settings: {
+    invoice_number_prefix?: string | null;
+    invoice_number_next?: number | null;
+    default_payment_terms?: number | null;
+    default_currency?: string | null;
+    default_tax_rate?: number | null;
+    tax_label?: string | null;
+    payment_method_options?: string[] | null;
+  };
+}
+
+const CURRENCIES = ["USD", "EUR", "GBP", "CAD", "AUD", "NZD", "CHF"];
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" disabled={pending}>
+      {pending ? "Saving…" : "Save"}
+    </Button>
+  );
+}
+
+export function InvoiceSettingsForm({ settings }: Props) {
+  const [state, formAction] = useActionState(updateInvoiceSettingsAction, null);
+  const [methods, setMethods] = useState<string[]>(
+    settings.payment_method_options ?? ["Check", "ACH", "Wire", "Credit Card", "Other"]
+  );
+  const [newMethod, setNewMethod] = useState("");
+
+  function addMethod() {
+    const trimmed = newMethod.trim();
+    if (trimmed && !methods.includes(trimmed)) {
+      setMethods([...methods, trimmed]);
+    }
+    setNewMethod("");
+  }
+
+  function removeMethod(m: string) {
+    setMethods(methods.filter((x) => x !== m));
+  }
+
+  // stored as 0–1 decimal; display as 0–100 percentage
+  const taxRatePct = settings.default_tax_rate != null
+    ? (settings.default_tax_rate * 100).toFixed(4).replace(/\.?0+$/, "")
+    : "0";
+
+  return (
+    <form action={formAction} className="space-y-5 max-w-2xl">
+      {state?.error && (
+        <Alert variant="destructive">
+          <AlertDescription>{state.error}</AlertDescription>
+        </Alert>
+      )}
+      {state && !state.error && (
+        <Alert>
+          <AlertDescription>Saved.</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="invoice_number_prefix">Invoice number prefix</Label>
+          <Input
+            id="invoice_number_prefix"
+            name="invoice_number_prefix"
+            defaultValue={settings.invoice_number_prefix ?? "INV-"}
+            placeholder="INV-"
+            className="font-mono"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="invoice_number_next">Next invoice number</Label>
+          <Input
+            id="invoice_number_next"
+            name="invoice_number_next"
+            type="number"
+            min="1"
+            step="1"
+            defaultValue={settings.invoice_number_next ?? 1001}
+          />
+          <p className="text-xs text-muted-foreground">
+            The sequence counter for the next invoice.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="default_payment_terms">Default payment terms (days)</Label>
+          <Input
+            id="default_payment_terms"
+            name="default_payment_terms"
+            type="number"
+            min="0"
+            step="1"
+            defaultValue={settings.default_payment_terms ?? 30}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="default_currency">Default currency</Label>
+          <Select
+            name="default_currency"
+            defaultValue={settings.default_currency ?? "USD"}
+          >
+            <SelectTrigger id="default_currency">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CURRENCIES.map((c) => (
+                <SelectItem key={c} value={c}>
+                  {c}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="tax_label">Tax label</Label>
+          <Input
+            id="tax_label"
+            name="tax_label"
+            defaultValue={settings.tax_label ?? "Tax"}
+            placeholder="Tax"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="default_tax_rate">Default tax rate (%)</Label>
+          <Input
+            id="default_tax_rate"
+            name="default_tax_rate"
+            type="number"
+            min="0"
+            max="100"
+            step="0.01"
+            defaultValue={taxRatePct}
+            placeholder="0"
+          />
+        </div>
+      </div>
+
+      {/* Payment methods tag input */}
+      <div className="space-y-2">
+        <Label>Payment method options</Label>
+        <input
+          type="hidden"
+          name="payment_method_options"
+          value={JSON.stringify(methods)}
+        />
+        <div className="flex flex-wrap gap-1.5">
+          {methods.map((m) => (
+            <span
+              key={m}
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium"
+            >
+              {m}
+              <button
+                type="button"
+                onClick={() => removeMethod(m)}
+                className="ml-0.5 rounded text-muted-foreground hover:text-foreground"
+                aria-label={`Remove ${m}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <Input
+            value={newMethod}
+            onChange={(e) => setNewMethod(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addMethod();
+              }
+            }}
+            placeholder="Add option…"
+            className="max-w-xs"
+          />
+          <Button type="button" variant="outline" size="sm" onClick={addMethod}>
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="pt-2">
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}

--- a/components/settings/TenantSlugForm.tsx
+++ b/components/settings/TenantSlugForm.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { updateTenantSlugAction } from "@/app/actions/settings";
+
+interface Props {
+  slug: string;
+  appUrl: string;
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" disabled={pending}>
+      {pending ? "Saving…" : "Save"}
+    </Button>
+  );
+}
+
+export function TenantSlugForm({ slug, appUrl }: Props) {
+  const [state, formAction] = useActionState(updateTenantSlugAction, null);
+
+  return (
+    <form action={formAction} className="space-y-4 max-w-md">
+      {state?.error && (
+        <Alert variant="destructive">
+          <AlertDescription>{state.error}</AlertDescription>
+        </Alert>
+      )}
+      {state && !state.error && (
+        <Alert>
+          <AlertDescription>Slug updated.</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-1.5">
+        <Label htmlFor="slug">Portal URL slug</Label>
+        <div className="flex items-center gap-0">
+          <span className="inline-flex h-9 items-center rounded-l-md border border-r-0 border-border bg-muted px-3 text-sm text-muted-foreground">
+            {appUrl}/portal/
+          </span>
+          <Input
+            id="slug"
+            name="slug"
+            defaultValue={slug}
+            className="rounded-l-none font-mono"
+            placeholder="my-business"
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Lowercase letters, numbers, and hyphens only.
+        </p>
+      </div>
+
+      <Alert variant="destructive" className="border-amber-500/50 bg-amber-50/50 text-amber-900 dark:bg-amber-950/30 dark:text-amber-200 [&>svg]:text-amber-500">
+        <AlertDescription>
+          Changing your slug will break existing portal bookmarks and shared links.
+        </AlertDescription>
+      </Alert>
+
+      <SubmitButton />
+    </form>
+  );
+}


### PR DESCRIPTION
Closes #5

## Summary
- **Settings page** (`/settings`): five independently-saveable sections — business info, branding (logo upload to R2, primary/accent color pickers), invoice defaults (prefix, numbering, currency, tax, payment methods tag editor), email templates (task-closed, invoice, comment, signature), and portal URL slug with uniqueness validation
- **Reports page** (`/reports`): URL-based date range filter (defaults to current year) with three tables — revenue by client, revenue by month, unbilled hours with estimated value
- No new DB migration — all columns already exist in `tenant_settings`

## Test plan
- [ ] Navigate to `/settings` — all sections render with current data
- [ ] Edit business info and save — confirm persists on reload
- [ ] Upload a logo — confirm R2 URL appears in preview
- [ ] Change primary/accent colors — confirm hex inputs stay in sync with color pickers
- [ ] Add/remove payment method tags, save — confirm array updates
- [ ] Change tenant slug to unique value — confirm saves; try a duplicate — confirm error
- [ ] Navigate to `/reports` — three tables render
- [ ] Change date range and apply — confirm tables update
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)