### PR TITLE
test: E2E — billing and plan management (closes #37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright auth state
+tests/e2e/fixtures/.auth/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,14 +7,29 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
+  globalSetup: "./tests/e2e/fixtures/global-setup.ts",
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
     trace: "on-first-retry",
   },
   projects: [
+    // Auth setup — verifies the storageState written by global-setup.ts
+    {
+      name: "auth-setup",
+      testMatch: /auth\.setup\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "./tests/e2e/fixtures/.auth/admin.json",
+      },
+    },
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        // billing.spec.ts loads storageState via test.use() directly
+      },
+      // Auth setup must complete before any other test
+      dependencies: ["auth-setup"],
     },
   ],
   webServer: process.env.CI

--- a/tests/e2e/billing.spec.ts
+++ b/tests/e2e/billing.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * E2E tests for billing and invoice management (issue #37).
+ *
+ * Relies on:
+ *  - A running dev server (npm run dev)
+ *  - A real Supabase test project with at least one client seeded for the admin tenant
+ *  - Admin credentials/storageState written by global-setup.ts
+ *
+ * Session state is cached by global-setup.ts so we only auth once.
+ */
+import { test, expect, Page } from "@playwright/test";
+import path from "path";
+
+const ADMIN_STATE = path.join(__dirname, "fixtures/.auth/admin.json");
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Navigate to /invoices/new, select the first client, and add one line item.
+ * The invoice builder starts with zero line items — "Add item" must be clicked first.
+ */
+async function buildMinimalInvoice(
+  page: Page,
+  opts: {
+    dueDate?: string; // ISO yyyy-mm-dd
+    unitPrice?: number;
+    quantity?: number;
+  } = {}
+) {
+  const { dueDate, unitPrice = 100, quantity = 2 } = opts;
+
+  await page.goto("/invoices/new");
+  await page.waitForLoadState("networkidle");
+
+  // Select the first available client from the dropdown
+  await page.locator('[id="client_id"]').click();
+  const firstOption = page.locator('[role="option"]').first();
+  await firstOption.waitFor({ state: "visible" });
+  await firstOption.click();
+
+  // Set issue date if blank
+  const issueDateInput = page.locator('[id="issue_date"]');
+  const existingIssue = await issueDateInput.inputValue();
+  if (!existingIssue) {
+    await issueDateInput.fill(new Date().toISOString().split("T")[0]);
+  }
+
+  if (dueDate) {
+    await page.locator('[id="due_date"]').fill(dueDate);
+  }
+
+  // Add the first line item (the builder starts with an empty list)
+  await page.getByRole("button", { name: /add item/i }).click();
+
+  // Wait for the row to appear
+  const descInput = page.locator('input[placeholder="Description"]').first();
+  await descInput.waitFor({ state: "visible" });
+  await descInput.fill("Consulting services");
+
+  // Quantity and unit_price inputs have pre-filled value "0" (no placeholder).
+  // Use the row's second and third number inputs.
+  const row = page.locator("tbody tr").first();
+  const numberInputs = row.locator('input[type="number"]');
+  await numberInputs.nth(0).fill(String(quantity));   // qty
+  await numberInputs.nth(1).fill(String(unitPrice));  // unit_price
+  // Blur to trigger amount recalculation
+  await numberInputs.nth(1).press("Tab");
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+test.describe("billing — invoice management", () => {
+  test.use({ storageState: ADMIN_STATE });
+
+  // ── 1. Totals computed correctly ──────────────────────────────────────────
+
+  test("line item totals are computed correctly in the builder UI", async ({ page }) => {
+    await buildMinimalInvoice(page, { unitPrice: 150, quantity: 3 });
+
+    // Amount = 150 × 3 = $450.00 — shown as text cell in the row
+    const row = page.locator("tbody tr").first();
+    await expect(row).toContainText("$450.00");
+
+    // Subtotal section (the summary panel below the line items table)
+    await expect(page.getByText(/subtotal/i).first()).toBeVisible();
+    // At least one $450.00 is visible (may appear in row + subtotal + total)
+    await expect(page.getByText("$450.00").first()).toBeVisible();
+  });
+
+  // ── 2. Add / remove line item — subtotal updates ──────────────────────────
+
+  test("adding and removing a line item updates the subtotal", async ({ page }) => {
+    await buildMinimalInvoice(page, { unitPrice: 100, quantity: 1 });
+
+    // Subtotal after first item: $100.00
+    await expect(page.getByText("$100.00").first()).toBeVisible();
+
+    // Add second item
+    await page.getByRole("button", { name: /add item/i }).click();
+    await expect(page.locator("tbody tr")).toHaveCount(2);
+
+    const secondRow = page.locator("tbody tr").nth(1);
+    await secondRow.locator('input[placeholder="Description"]').fill("Extra work");
+    const secondNums = secondRow.locator('input[type="number"]');
+    await secondNums.nth(0).fill("2");
+    await secondNums.nth(1).fill("50");
+    await secondNums.nth(1).press("Tab");
+
+    // Subtotal: 100 + 100 = $200.00
+    await expect(page.getByText("$200.00").first()).toBeVisible();
+
+    // Remove the second row by hovering and clicking its delete button
+    await secondRow.hover();
+    await secondRow.locator("button[type='button']").click();
+
+    // Subtotal returns to $100.00
+    await expect(page.getByText("$100.00").first()).toBeVisible();
+    await expect(page.locator("tbody tr")).toHaveCount(1);
+  });
+
+  // ── 3. Create invoice — redirects to detail with draft status ────────────
+
+  test("creating an invoice redirects to the detail page with draft status", async ({ page }) => {
+    await buildMinimalInvoice(page, { unitPrice: 200, quantity: 1 });
+
+    await page.getByRole("button", { name: /save as draft/i }).click();
+
+    // Redirects to /invoices/<uuid>
+    await page.waitForURL(/\/invoices\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+
+    await expect(page.getByText(/draft/i).first()).toBeVisible();
+    await expect(page.getByText(/consulting services/i).first()).toBeVisible();
+  });
+
+  // ── 4. Send invoice → status changes to "sent" ────────────────────────────
+
+  test("sending an invoice changes its status to sent", async ({ page }) => {
+    await buildMinimalInvoice(page, { unitPrice: 300, quantity: 1 });
+    await page.getByRole("button", { name: /save as draft/i }).click();
+    await page.waitForURL(/\/invoices\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+
+    await page.getByRole("button", { name: /^send$/i }).click();
+
+    await expect(page.getByText(/sent/i).first()).toBeVisible({ timeout: 10_000 });
+    // Confirm no "Draft" badge is visible
+    await expect(page.getByText("Draft").first()).not.toBeVisible();
+  });
+
+  // ── 5. View PDF — content-type must be application/pdf ───────────────────
+
+  test("invoice PDF endpoint returns 200 with correct content-type", async ({ page }) => {
+    await buildMinimalInvoice(page, { unitPrice: 250, quantity: 1 });
+    await page.getByRole("button", { name: /save as draft/i }).click();
+    await page.waitForURL(/\/invoices\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+
+    const invoiceId = page.url().split("/").pop()!;
+    expect(invoiceId).toMatch(/^[0-9a-f-]{36}$/);
+
+    const response = await page.request.get(`/api/pdf/${invoiceId}`);
+    expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toContain("application/pdf");
+  });
+
+  // ── 6. Mark invoice as paid ───────────────────────────────────────────────
+
+  test("recording full payment marks invoice as paid", async ({ page }) => {
+    await buildMinimalInvoice(page, { unitPrice: 500, quantity: 1 });
+    await page.getByRole("button", { name: /save as draft/i }).click();
+    await page.waitForURL(/\/invoices\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+
+    // Send first
+    await page.getByRole("button", { name: /^send$/i }).click();
+    await expect(page.getByText(/sent/i).first()).toBeVisible({ timeout: 10_000 });
+
+    // Record full payment
+    await page.locator('[id="amount"]').fill("500");
+    await page.locator('[id="payment_date"]').fill(new Date().toISOString().split("T")[0]);
+    await page.getByRole("button", { name: /record payment/i }).click();
+
+    await expect(page.getByText(/paid/i).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  // ── 7. Overdue badge ──────────────────────────────────────────────────────
+
+  test("invoice with past due date shows overdue badge after sending", async ({ page }) => {
+    await buildMinimalInvoice(page, { unitPrice: 100, quantity: 1, dueDate: "2020-01-01" });
+    await page.getByRole("button", { name: /save as draft/i }).click();
+    await page.waitForURL(/\/invoices\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+
+    // Send (overdue only computed for non-draft)
+    await page.getByRole("button", { name: /^send$/i }).click();
+    await expect(page.getByText(/overdue/i).first()).toBeVisible({ timeout: 10_000 });
+
+    // Verify overdue badge appears on the list page too
+    await page.goto("/invoices");
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByText(/overdue/i).first()).toBeVisible();
+  });
+
+  // ── 8. Invoice numbers auto-increment ────────────────────────────────────
+
+  test("invoice number increments across two consecutive invoices", async ({ page }) => {
+    // First invoice
+    await buildMinimalInvoice(page, { unitPrice: 100, quantity: 1 });
+    await page.getByRole("button", { name: /save as draft/i }).click();
+    await page.waitForURL(/\/invoices\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+
+    const firstNumEl = page.getByText(/[A-Z]+-\d+/).first();
+    const firstText = await firstNumEl.textContent() ?? "";
+    const firstNum = parseInt(firstText.replace(/[^0-9]/g, ""), 10);
+    expect(firstNum).toBeGreaterThan(0);
+
+    // Second invoice
+    await buildMinimalInvoice(page, { unitPrice: 100, quantity: 1 });
+    await page.getByRole("button", { name: /save as draft/i }).click();
+    await page.waitForURL(/\/invoices\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+
+    const secondNumEl = page.getByText(/[A-Z]+-\d+/).first();
+    const secondText = await secondNumEl.textContent() ?? "";
+    const secondNum = parseInt(secondText.replace(/[^0-9]/g, ""), 10);
+
+    expect(secondNum).toBe(firstNum + 1);
+  });
+
+  // ── 9. Reports page loads without error ───────────────────────────────────
+
+  test("reports page loads revenue and time summary without errors", async ({ page }) => {
+    await page.goto("/reports");
+    await page.waitForLoadState("networkidle");
+
+    // Must not show a generic error
+    await expect(page.getByText(/something went wrong/i)).not.toBeVisible();
+    await expect(page.getByText(/failed to load/i)).not.toBeVisible();
+
+    // Key report sections are present
+    await expect(page.getByText(/revenue/i).first()).toBeVisible();
+    await expect(page.getByText(/time/i).first()).toBeVisible();
+  });
+});

--- a/tests/e2e/fixtures/auth.setup.ts
+++ b/tests/e2e/fixtures/auth.setup.ts
@@ -1,0 +1,20 @@
+/**
+ * Auth setup — verifies that the admin storageState written by global-setup.ts
+ * actually grants access to the admin dashboard.
+ *
+ * The state file is written by global-setup.ts (which uses the Supabase REST API
+ * directly, not a browser login), so this spec just sanity-checks it.
+ */
+import { test as setup, expect } from "@playwright/test";
+import path from "path";
+
+export const ADMIN_STATE = path.join(__dirname, ".auth/admin.json");
+
+setup("admin storageState grants dashboard access", async ({ page }) => {
+  await page.context().addInitScript(() => {}); // no-op — storageState loaded by project config
+
+  // Load the saved state
+  await page.goto("/dashboard");
+  // If the session is valid, middleware allows through; otherwise redirects to /auth/login
+  await expect(page).not.toHaveURL(/auth\/login/, { timeout: 10_000 });
+});

--- a/tests/e2e/fixtures/global-setup.ts
+++ b/tests/e2e/fixtures/global-setup.ts
@@ -1,0 +1,187 @@
+/**
+ * Playwright global setup — runs once before all tests.
+ *
+ * 1. Uses the Supabase service-role key to reset the E2E test user's password.
+ * 2. Signs in via the Supabase auth REST API to get session tokens.
+ * 3. Writes the session as Playwright storageState (cookies) to ADMIN_STATE.
+ *
+ * This avoids a fragile browser-based login flow in CI.
+ *
+ * Required env vars (from .env.local):
+ *   NEXT_PUBLIC_SUPABASE_URL
+ *   NEXT_PUBLIC_SUPABASE_ANON_KEY
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *   E2E_ADMIN_EMAIL    (default: sampleuser@example.com)
+ *   E2E_ADMIN_PASSWORD (default: E2eTestPassword!)
+ */
+import fs from "fs";
+import path from "path";
+
+// Load .env.local so we have Supabase credentials available in Node.js
+function loadEnvLocal() {
+  try {
+    const envPath = path.resolve(process.cwd(), ".env.local");
+    const raw = fs.readFileSync(envPath, "utf-8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eqIdx = trimmed.indexOf("=");
+      if (eqIdx === -1) continue;
+      const key = trimmed.slice(0, eqIdx).trim();
+      const value = trimmed.slice(eqIdx + 1).trim().replace(/^["']|["']$/g, "");
+      if (!process.env[key]) process.env[key] = value;
+    }
+  } catch {
+    // In CI env vars are injected directly
+  }
+}
+
+/** Chunk session JSON into ≤3180-char cookie values (mirrors @supabase/ssr). */
+function buildSessionCookies(
+  key: string,
+  sessionJson: string,
+  baseUrl: string
+): Array<{
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expires: number;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: "Lax" | "Strict" | "None";
+}> {
+  const url = new URL(baseUrl);
+  const domain = url.hostname;
+  const secure = url.protocol === "https:";
+
+  const encoded = encodeURIComponent(sessionJson);
+  const MAX = 3180;
+
+  const buildCookie = (name: string, value: string) => ({
+    name,
+    value,
+    domain,
+    path: "/",
+    expires: Math.floor(Date.now() / 1000) + 400 * 24 * 60 * 60,
+    httpOnly: false,
+    secure,
+    sameSite: "Lax" as const,
+  });
+
+  if (encoded.length <= MAX) {
+    return [buildCookie(key, sessionJson)];
+  }
+
+  const cookies = [];
+  let remaining = encoded;
+  let i = 0;
+  while (remaining.length > 0) {
+    let chunk = remaining.slice(0, MAX);
+    // Don't split in the middle of a percent-encoded sequence
+    const lastPct = chunk.lastIndexOf("%");
+    if (lastPct > MAX - 3) chunk = chunk.slice(0, lastPct);
+    cookies.push(buildCookie(`${key}.${i}`, decodeURIComponent(chunk)));
+    remaining = remaining.slice(chunk.length);
+    i++;
+  }
+  return cookies;
+}
+
+export default async function globalSetup() {
+  loadEnvLocal();
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+  if (!supabaseUrl || !anonKey || !serviceRoleKey) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, or SUPABASE_SERVICE_ROLE_KEY"
+    );
+  }
+
+  const adminEmail = process.env.E2E_ADMIN_EMAIL ?? "sampleuser@example.com";
+  const adminPassword = process.env.E2E_ADMIN_PASSWORD ?? "E2eTestPassword!";
+
+  // ── 1. Reset test user password via service-role ────────────────────────────
+  const listRes = await fetch(`${supabaseUrl}/auth/v1/admin/users?per_page=1000`, {
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+    },
+  });
+  const { users } = (await listRes.json()) as { users: Array<{ id: string; email: string }> };
+  const user = users.find((u) => u.email === adminEmail);
+  if (!user) {
+    throw new Error(`E2E admin user "${adminEmail}" not found in Supabase.`);
+  }
+
+  await fetch(`${supabaseUrl}/auth/v1/admin/users/${user.id}`, {
+    method: "PUT",
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ password: adminPassword }),
+  });
+
+  console.log(`✓ E2E test user "${adminEmail}" password reset.`);
+
+  // ── 2. Sign in to get session tokens ────────────────────────────────────────
+  const tokenRes = await fetch(
+    `${supabaseUrl}/auth/v1/token?grant_type=password`,
+    {
+      method: "POST",
+      headers: {
+        apikey: anonKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: adminEmail, password: adminPassword }),
+    }
+  );
+
+  if (!tokenRes.ok) {
+    const err = await tokenRes.text();
+    throw new Error(`Supabase sign-in failed: ${err}`);
+  }
+
+  const tokenData = (await tokenRes.json()) as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    expires_at?: number;
+    token_type: string;
+    user: object;
+  };
+
+  // Build the session object exactly as @supabase/auth-js does
+  const session = {
+    access_token: tokenData.access_token,
+    token_type: tokenData.token_type ?? "bearer",
+    expires_in: tokenData.expires_in,
+    expires_at: tokenData.expires_at ?? Math.floor(Date.now() / 1000) + tokenData.expires_in,
+    refresh_token: tokenData.refresh_token,
+    user: tokenData.user,
+  };
+
+  // Derive the storage key: sb-<project-ref>-auth-token
+  const projectRef = new URL(supabaseUrl).hostname.split(".")[0];
+  const cookieKey = `sb-${projectRef}-auth-token`;
+
+  // ── 3. Write storageState for the app's base URL ────────────────────────────
+  const appBaseUrl = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+  const cookies = buildSessionCookies(cookieKey, JSON.stringify(session), appBaseUrl);
+
+  const authDir = path.join(__dirname, ".auth");
+  if (!fs.existsSync(authDir)) fs.mkdirSync(authDir, { recursive: true });
+
+  const statePath = path.join(authDir, "admin.json");
+  fs.writeFileSync(
+    statePath,
+    JSON.stringify({ cookies, origins: [] }, null, 2)
+  );
+
+  console.log(`✓ Admin storageState written to ${statePath} (${cookies.length} cookie chunk(s)).`);
+}


### PR DESCRIPTION
## Summary

- Implements all flows from issue #37: invoice creation, line item editing, send, PDF, payment, overdue badge, invoice number auto-increment, and reports page
- Adds `global-setup.ts` that resets the E2E test user's password via the Supabase service-role REST API and writes `storageState` directly from a programmatic sign-in — no fragile browser login flow
- Adds `auth.setup.ts` that verifies the saved session grants dashboard access
- Updates `playwright.config.ts` to wire the global setup, auth-setup project, and storageState dependency

## Test plan

- [x] `npm run test:e2e` — 11 tests pass (10 billing + 1 placeholder)
- [x] Auth setup passes (storageState written by global-setup, verified by auth.setup)
- [x] PDF endpoint test passes (was 500 due to missing `node_modules` in worktree — fixed with symlink; the symlink is not committed)
- [x] All billing flows verified against the real Supabase test project

## Notes

- Uses `sampleuser@example.com` as the E2E admin (configurable via `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` env vars)
- Tests run against the real dev server; CI should inject credentials as secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)