### PR TITLE
feat: Phase 8 — polish and production hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Built with Next.js 16 App Router, Supabase, and a fully type-safe stack. Each te
 ### UX
 - **Optimistic UI** — instant feedback on status changes with background server sync
 - **Loading skeletons** — skeleton screens on all data-heavy pages for perceived performance
-- **Dark mode** — first-class dark mode via CSS variables throughout
+- **Dark mode** — first-class dark mode via CSS variables; toggle in sidebar footer; respects system preference with no flash
+- **Mobile responsive** — hamburger sidebar on mobile, horizontal-scroll tables, single-column kanban
+- **Email audit log** — read-only table of all sent emails at `/email-log`
+- **Error boundaries** — `error.tsx` and `not-found.tsx` at the route-segment level
 
 ## Tech Stack
 
@@ -153,13 +156,14 @@ Open [http://localhost:3000](http://localhost:3000). Register a new account (req
 ## Available Scripts
 
 ```bash
-npm run dev      # Start development server
-npm run build    # Production build + TypeScript type-check
-npm run lint     # ESLint
-npm run start    # Serve production build
+npm run dev        # Start development server
+npm run build      # Production build + TypeScript type-check
+npm run lint       # ESLint
+npm run start      # Serve production build
+npm run test       # All tests (unit + integration)
+npm run test:unit  # Vitest unit/integration tests
+npm run test:e2e   # Playwright E2E tests (requires dev server running)
 ```
-
-> There are no automated tests. `npm run build` is the primary correctness check — always run it after changes.
 
 ## Deployment
 
@@ -185,8 +189,8 @@ DNS is managed on Cloudflare with a grey-cloud (DNS-only) CNAME pointing to Verc
 | 3 | Task management + Milkdown editor + R2 uploads | ✅ Done |
 | 4 | Time tracking + FullCalendar | ✅ Done |
 | 5 | Invoicing + React-PDF | ✅ Done |
-| 6a | Client portal | Pending |
-| 6b | Portal: magic link auth | Pending |
-| 6c | Portal: Google OAuth | Pending |
-| 7 | Settings + reports | Pending |
-| 8 | Polish + hardening | Pending |
+| 6a | Client portal | ✅ Done |
+| 6b | Portal: magic link auth | ✅ Done |
+| 6c | Portal: Google OAuth | ✅ Done |
+| 7 | Settings + reports | ✅ Done |
+| 8 | Polish + hardening | ✅ Done |

--- a/app/(admin)/clients/loading.tsx
+++ b/app/(admin)/clients/loading.tsx
@@ -1,0 +1,43 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-6 pl-14 md:pl-6">
+        <div className="h-4 w-24 rounded bg-muted animate-pulse" />
+        <div className="h-7 w-24 rounded bg-muted/50 animate-pulse" />
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-6 space-y-4">
+        {/* Search/filter row */}
+        <div className="h-8 w-72 rounded bg-muted/40 animate-pulse" />
+
+        {/* Table */}
+        <div className="rounded-md border border-border overflow-hidden">
+          <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-4">
+            <div className="h-2.5 flex-1 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-32 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+          </div>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 h-12 border-b border-border last:border-0 px-4"
+            >
+              <div className="flex items-center gap-2.5 flex-1">
+                <div className="h-2 w-2 rounded-full bg-muted/60 animate-pulse" />
+                <div className="h-3.5 w-32 rounded bg-muted/50 animate-pulse" />
+              </div>
+              <div className="h-3 w-40 rounded bg-muted/40 animate-pulse" />
+              <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+              <div className="h-3 w-16 rounded bg-muted/40 animate-pulse" />
+              <div className="h-5 w-14 rounded-full bg-muted/40 animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/clients/page.tsx
+++ b/app/(admin)/clients/page.tsx
@@ -51,8 +51,8 @@ async function ClientTable({ q, archived }: { q?: string; archived?: string }) {
   }
 
   return (
-    <div className="rounded-md border border-border">
-      <table className="w-full text-sm">
+    <div className="rounded-md border border-border overflow-x-auto">
+      <table className="w-full min-w-[600px] text-sm">
         <thead>
           <tr className="border-b border-border bg-muted/40">
             <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Client</th>

--- a/app/(admin)/email-log/loading.tsx
+++ b/app/(admin)/email-log/loading.tsx
@@ -1,0 +1,30 @@
+export default function Loading() {
+  return (
+    <>
+      <div className="flex h-14 items-center justify-between border-b border-border px-6 pl-14 md:pl-6">
+        <div className="space-y-1">
+          <div className="h-4 w-24 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-32 rounded bg-muted/40 animate-pulse" />
+        </div>
+      </div>
+      <div className="p-6">
+        <div className="rounded-md border border-border overflow-hidden">
+          <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-4">
+            {[20, 16, 24, 40, 12].map((w, i) => (
+              <div key={i} className={`h-2.5 w-${w} rounded bg-muted animate-pulse`} />
+            ))}
+          </div>
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 h-11 border-b border-border last:border-0 px-4">
+              <div className="h-3 w-32 rounded bg-muted/60 animate-pulse" />
+              <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+              <div className="h-3 w-40 rounded bg-muted/40 animate-pulse" />
+              <div className="h-3 flex-1 rounded bg-muted/40 animate-pulse" />
+              <div className="h-5 w-12 rounded-full bg-muted/40 animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/email-log/page.tsx
+++ b/app/(admin)/email-log/page.tsx
@@ -1,0 +1,102 @@
+import { createClient } from "@/lib/supabase/server";
+import { TopBar } from "@/components/layout/TopBar";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { Badge } from "@/components/ui/badge";
+import { Mail } from "lucide-react";
+
+const TYPE_LABELS: Record<string, string> = {
+  task_closed: "Task closed",
+  invoice: "Invoice",
+  comment: "Comment",
+};
+
+const STATUS_VARIANTS: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  sent: "default",
+  failed: "destructive",
+};
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default async function EmailLogPage() {
+  const supabase = await createClient();
+
+  const { data: logs, error } = await supabase
+    .from("email_log")
+    .select("id, created_at, type, to_email, subject, status, resend_id, error_message")
+    .order("created_at", { ascending: false })
+    .limit(200);
+
+  return (
+    <>
+      <TopBar title="Email Log" description="Last 200 sent emails" />
+      <PageContainer>
+        {error ? (
+          <p className="text-sm text-destructive">Failed to load email log: {error.message}</p>
+        ) : !logs?.length ? (
+          <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-border py-16 text-center">
+            <Mail className="mx-auto h-8 w-8 text-muted-foreground mb-3" strokeWidth={1.5} />
+            <p className="text-sm font-medium">No emails sent yet.</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Emails are logged when tasks are closed, invoices are sent, and portal comments are posted.
+            </p>
+          </div>
+        ) : (
+          <div className="rounded-md border border-border overflow-x-auto">
+            <table className="w-full min-w-[700px] text-sm">
+              <thead>
+                <tr className="border-b border-border bg-muted/40">
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Sent at</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Type</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">To</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Subject</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {logs.map((log) => (
+                  <tr key={log.id} className="hover:bg-muted/20 transition-colors">
+                    <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap tabular-nums">
+                      {formatDate(log.created_at)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="text-xs text-muted-foreground">
+                        {TYPE_LABELS[log.type] ?? log.type}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-xs max-w-[200px] truncate text-muted-foreground">
+                      {log.to_email}
+                    </td>
+                    <td className="px-4 py-3 text-xs max-w-[280px] truncate">
+                      {log.subject}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge
+                        variant={STATUS_VARIANTS[log.status] ?? "secondary"}
+                        className="text-xs capitalize"
+                      >
+                        {log.status}
+                      </Badge>
+                      {log.status === "failed" && log.error_message && (
+                        <p className="mt-0.5 text-xs text-destructive truncate max-w-[200px]" title={log.error_message}>
+                          {log.error_message}
+                        </p>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </PageContainer>
+    </>
+  );
+}

--- a/app/(admin)/error.tsx
+++ b/app/(admin)/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle } from "lucide-react";
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <AlertTriangle className="h-10 w-10 text-destructive" strokeWidth={1.5} />
+      <div>
+        <h2 className="text-base font-semibold">Something went wrong</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          An unexpected error occurred. Please try again.
+        </p>
+      </div>
+      <Button size="sm" variant="outline" onClick={reset}>
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/app/(admin)/invoices/loading.tsx
+++ b/app/(admin)/invoices/loading.tsx
@@ -1,0 +1,48 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-6 pl-14 md:pl-6">
+        <div className="h-4 w-24 rounded bg-muted animate-pulse" />
+        <div className="h-7 w-28 rounded bg-muted/50 animate-pulse" />
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-6 space-y-4">
+        {/* Filter row */}
+        <div className="flex items-center gap-3">
+          <div className="h-7 w-36 rounded bg-muted/40 animate-pulse" />
+          <div className="h-7 w-36 rounded bg-muted/40 animate-pulse" />
+        </div>
+
+        {/* Table */}
+        <div className="rounded-md border border-border overflow-hidden">
+          <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-4">
+            <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 flex-1 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+          </div>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 h-12 border-b border-border last:border-0 px-4"
+            >
+              <div className="h-3.5 w-16 rounded bg-muted/60 animate-pulse font-mono" />
+              <div className="flex items-center gap-1.5 flex-1">
+                <div className="h-2 w-2 rounded-full bg-muted/60 animate-pulse" />
+                <div className="h-3 w-28 rounded bg-muted/50 animate-pulse" />
+              </div>
+              <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+              <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+              <div className="h-3 w-16 rounded bg-muted/40 animate-pulse ml-auto" />
+              <div className="h-5 w-16 rounded-full bg-muted/40 animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { UserMenu } from "@/components/layout/UserMenu";
+import { SidebarShell } from "@/components/layout/SidebarShell";
 
 export default async function AdminLayout({
   children,
@@ -25,15 +26,16 @@ export default async function AdminLayout({
     .single();
 
   return (
-    <div className="flex min-h-screen">
-      <aside className="fixed inset-y-0 left-0 z-50 flex w-56 flex-col border-r border-border bg-background">
-        <Sidebar />
+    <SidebarShell
+      sidebar={<Sidebar />}
+      userMenu={
         <UserMenu
           email={user.email ?? ""}
           name={profile?.full_name ?? undefined}
         />
-      </aside>
-      <div className="flex flex-1 flex-col pl-56">{children}</div>
-    </div>
+      }
+    >
+      {children}
+    </SidebarShell>
   );
 }

--- a/app/(admin)/not-found.tsx
+++ b/app/(admin)/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { FileQuestion } from "lucide-react";
+
+export default function AdminNotFound() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <FileQuestion className="h-10 w-10 text-muted-foreground" strokeWidth={1.5} />
+      <div>
+        <h2 className="text-base font-semibold">Page not found</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+      </div>
+      <Button size="sm" variant="outline" asChild>
+        <Link href="/dashboard">Go to dashboard</Link>
+      </Button>
+    </div>
+  );
+}

--- a/app/(admin)/time/list/loading.tsx
+++ b/app/(admin)/time/list/loading.tsx
@@ -1,0 +1,46 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-6 pl-14 md:pl-6">
+        <div className="h-4 w-28 rounded bg-muted animate-pulse" />
+        <div className="h-7 w-20 rounded bg-muted/50 animate-pulse" />
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-6 space-y-4">
+        {/* Summary + button row */}
+        <div className="flex items-center justify-between">
+          <div className="h-3.5 w-40 rounded bg-muted/40 animate-pulse" />
+          <div className="h-7 w-20 rounded bg-muted/50 animate-pulse" />
+        </div>
+
+        {/* Table */}
+        <div className="rounded-md border border-border overflow-hidden">
+          <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-3">
+            <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 flex-1 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-32 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-12 rounded bg-muted animate-pulse" />
+            <div className="h-2.5 w-12 rounded bg-muted animate-pulse" />
+          </div>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 h-11 border-b border-border last:border-0 px-3"
+            >
+              <div className="h-3 w-20 rounded bg-muted/60 animate-pulse" />
+              <div className="flex-1 space-y-1">
+                <div className="h-3 w-28 rounded bg-muted/50 animate-pulse" />
+                <div className="h-2.5 w-36 rounded bg-muted/40 animate-pulse" />
+              </div>
+              <div className="h-3 w-32 rounded bg-muted/40 animate-pulse" />
+              <div className="h-3.5 w-10 rounded bg-muted/40 animate-pulse" />
+              <div className="h-3 w-8 rounded bg-muted/40 animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/time/loading.tsx
+++ b/app/(admin)/time/loading.tsx
@@ -1,0 +1,19 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-6 pl-14 md:pl-6">
+        <div className="h-4 w-28 rounded bg-muted animate-pulse" />
+        <div className="flex gap-2">
+          <div className="h-7 w-20 rounded bg-muted/50 animate-pulse" />
+          <div className="h-7 w-20 rounded bg-muted/50 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Calendar placeholder */}
+      <div className="p-6">
+        <div className="rounded-md border border-border animate-pulse bg-muted/20" style={{ minHeight: 540 }} />
+      </div>
+    </>
+  );
+}

--- a/app/api/email/comment/comment.test.ts
+++ b/app/api/email/comment/comment.test.ts
@@ -5,6 +5,7 @@ import { NextRequest } from "next/server";
 
 const mockEmailsSend = vi.hoisted(() => vi.fn());
 const mockFrom = vi.hoisted(() => vi.fn());
+const mockGetUser = vi.hoisted(() => vi.fn());
 
 vi.mock("resend", () => ({
   // Use a class so `new Resend(...)` works in Vitest v4
@@ -13,9 +14,15 @@ vi.mock("resend", () => ({
   },
 }));
 
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => Promise.resolve({ auth: { getUser: mockGetUser } }),
+}));
+
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({ from: mockFrom }),
 }));
+
+const clientUser = { id: "user-1", app_metadata: { role: "client" } };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -67,6 +74,17 @@ function mockEmailLogInsert() {
 describe("POST /api/email/comment", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // Default: authenticated client user (comment route requires any authenticated user)
+    mockGetUser.mockResolvedValue({ data: { user: clientUser } });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ commentId: "comment-1" }));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/unauthorized/i);
   });
 
   it("returns 400 when commentId is missing", async () => {

--- a/app/api/email/comment/route.ts
+++ b/app/api/email/comment/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
+import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 export async function POST(request: NextRequest) {
+  const caller = await createClient();
+  const { data: { user } } = await caller.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { commentId } = await request.json();
 
   if (!commentId) {

--- a/app/api/email/invoice/route.ts
+++ b/app/api/email/invoice/route.ts
@@ -2,12 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { renderToBuffer } from "@react-pdf/renderer";
 import { createElement } from "react";
 import { Resend } from "resend";
+import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { InvoicePDF } from "@/components/invoices/InvoicePDF";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 export async function POST(request: NextRequest) {
+  const caller = await createClient();
+  const { data: { user } } = await caller.auth.getUser();
+  if (!user || user.app_metadata?.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { invoiceId } = await request.json();
 
   if (!invoiceId) {

--- a/app/api/email/task-closed/route.ts
+++ b/app/api/email/task-closed/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
+import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 export async function POST(request: NextRequest) {
+  const caller = await createClient();
+  const { data: { user } } = await caller.auth.getUser();
+  if (!user || user.app_metadata?.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { taskId } = await request.json();
 
   if (!taskId) {

--- a/app/api/email/task-closed/task-closed.test.ts
+++ b/app/api/email/task-closed/task-closed.test.ts
@@ -5,6 +5,7 @@ import { NextRequest } from "next/server";
 
 const mockEmailsSend = vi.hoisted(() => vi.fn());
 const mockFrom = vi.hoisted(() => vi.fn());
+const mockGetUser = vi.hoisted(() => vi.fn());
 
 vi.mock("resend", () => ({
   // Use a class so `new Resend(...)` works in Vitest v4
@@ -13,9 +14,15 @@ vi.mock("resend", () => ({
   },
 }));
 
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => Promise.resolve({ auth: { getUser: mockGetUser } }),
+}));
+
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({ from: mockFrom }),
 }));
+
+const adminUser = { id: "user-1", app_metadata: { role: "admin" } };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -54,6 +61,24 @@ describe("POST /api/email/task-closed", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    // Default: authenticated admin user
+    mockGetUser.mockResolvedValue({ data: { user: adminUser } });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ taskId: "task-1" }));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 401 when user is not an admin", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "u2", app_metadata: { role: "client" } } } });
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ taskId: "task-1" }));
+    expect(res.status).toBe(401);
   });
 
   it("returns 400 when taskId is missing", async () => {

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -15,7 +15,7 @@ const ALLOWED_MIME_TYPES = new Set([
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ]);
 
-const MAX_SIZE = 20 * 1024 * 1024; // 20 MB
+const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
 
 function getS3Client() {
   const accountId = process.env.R2_ACCOUNT_ID;
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest) {
   }
 
   if (file.size > MAX_SIZE) {
-    return NextResponse.json({ error: "File exceeds 20 MB limit" }, { status: 413 });
+    return NextResponse.json({ error: "File exceeds 10 MB limit" }, { status: 413 });
   }
 
   if (!ALLOWED_MIME_TYPES.has(file.type)) {

--- a/app/api/upload/upload.test.ts
+++ b/app/api/upload/upload.test.ts
@@ -24,7 +24,7 @@ vi.mock("@aws-sdk/client-s3", () => ({
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-const MAX_SIZE = 20 * 1024 * 1024;
+const MAX_SIZE = 10 * 1024 * 1024;
 
 /**
  * Creates a NextRequest whose formData() is patched to avoid jsdom/undici
@@ -135,7 +135,7 @@ describe("POST /api/upload", () => {
     expect(json.error).toMatch(/no file/i);
   });
 
-  it("returns 413 when file exceeds 20 MB", async () => {
+  it("returns 413 when file exceeds 10 MB", async () => {
     mockGetUser.mockResolvedValueOnce({ data: { user: authenticatedUser } });
 
     const { POST } = await import("./route");
@@ -147,7 +147,7 @@ describe("POST /api/upload", () => {
     );
     expect(res.status).toBe(413);
     const json = await res.json();
-    expect(json.error).toMatch(/20 mb/i);
+    expect(json.error).toMatch(/10 mb/i);
   });
 
   it("returns 415 when file type is not allowed", async () => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Prevent flash of wrong theme by setting the class before first paint */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('theme');if(t==='dark'||(t===null&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark');}}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body className={`${GeistSans.variable} ${GeistMono.variable} font-sans antialiased`}>
         {children}
       </body>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { FileQuestion } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-center p-8">
+      <FileQuestion className="h-10 w-10 text-muted-foreground" strokeWidth={1.5} />
+      <div>
+        <h1 className="text-base font-semibold">404 — Page not found</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The page you&apos;re looking for doesn&apos;t exist.
+        </p>
+      </div>
+      <Link
+        href="/"
+        className="text-sm text-primary hover:underline"
+      >
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/app/portal/[tenantSlug]/error.tsx
+++ b/app/portal/[tenantSlug]/error.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+
+export default function PortalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 text-center p-8">
+      <AlertTriangle className="h-10 w-10 text-destructive" strokeWidth={1.5} />
+      <div>
+        <h2 className="text-base font-semibold">Something went wrong</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          An unexpected error occurred. Please try again.
+        </p>
+      </div>
+      <button
+        onClick={reset}
+        className="text-sm text-primary hover:underline"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/app/portal/[tenantSlug]/not-found.tsx
+++ b/app/portal/[tenantSlug]/not-found.tsx
@@ -1,0 +1,15 @@
+import { FileQuestion } from "lucide-react";
+
+export default function PortalNotFound() {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 text-center p-8">
+      <FileQuestion className="h-10 w-10 text-muted-foreground" strokeWidth={1.5} />
+      <div>
+        <h2 className="text-base font-semibold">Page not found</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The page you&apos;re looking for doesn&apos;t exist.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/invoices/InvoiceListView.tsx
+++ b/components/invoices/InvoiceListView.tsx
@@ -49,8 +49,8 @@ export function InvoiceListView({ invoices }: { invoices: Invoice[] }) {
   }
 
   return (
-    <div className="rounded-md border border-border">
-      <table className="w-full text-sm">
+    <div className="rounded-md border border-border overflow-x-auto">
+      <table className="w-full min-w-[640px] text-sm">
         <thead>
           <tr className="border-b border-border bg-muted/40">
             <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">#</th>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   BarChart2,
   Settings,
   Zap,
+  Mail,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -22,6 +23,7 @@ const navItems = [
   { href: "/invoices", label: "Invoices", icon: FileText },
   { href: "/reports", label: "Reports", icon: BarChart2 },
   { href: "/settings", label: "Settings", icon: Settings },
+  { href: "/email-log", label: "Email Log", icon: Mail },
 ];
 
 export function Sidebar() {

--- a/components/layout/SidebarShell.tsx
+++ b/components/layout/SidebarShell.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface SidebarShellProps {
+  sidebar: React.ReactNode;
+  userMenu: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function SidebarShell({ sidebar, userMenu, children }: SidebarShellProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen">
+      {/* Mobile backdrop */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          onClick={() => setMobileOpen(false)}
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        className={cn(
+          "fixed inset-y-0 left-0 z-50 flex w-56 flex-col border-r border-border bg-background transition-transform duration-200",
+          mobileOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"
+        )}
+      >
+        {sidebar}
+        {userMenu}
+      </aside>
+
+      {/* Mobile hamburger button — sits in the top bar area */}
+      <button
+        className="fixed left-4 top-3.5 z-40 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground md:hidden"
+        onClick={() => setMobileOpen((o) => !o)}
+        aria-label="Toggle navigation"
+      >
+        {mobileOpen ? (
+          <X className="h-5 w-5" strokeWidth={1.75} />
+        ) : (
+          <Menu className="h-5 w-5" strokeWidth={1.75} />
+        )}
+      </button>
+
+      {/* Main content */}
+      <div className="flex flex-1 flex-col pl-0 md:pl-56">{children}</div>
+    </div>
+  );
+}

--- a/components/layout/ThemeToggle.tsx
+++ b/components/layout/ThemeToggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Sun, Moon } from "lucide-react";
+
+export function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    setIsDark(document.documentElement.classList.contains("dark"));
+  }, []);
+
+  function toggle() {
+    const next = !isDark;
+    setIsDark(next);
+    if (next) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+    >
+      {isDark ? (
+        <Sun className="h-4 w-4 shrink-0" strokeWidth={1.75} />
+      ) : (
+        <Moon className="h-4 w-4 shrink-0" strokeWidth={1.75} />
+      )}
+      {isDark ? "Light mode" : "Dark mode"}
+    </button>
+  );
+}

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -8,7 +8,7 @@ interface TopBarProps {
 
 export function TopBar({ title, description, actions }: TopBarProps) {
   return (
-    <div className="flex h-14 items-center justify-between border-b border-border bg-background px-6">
+    <div className="flex h-14 items-center justify-between border-b border-border bg-background px-6 pl-14 md:pl-6">
       <div className="flex flex-col justify-center">
         <h1 className="text-sm font-semibold">{title}</h1>
         {description && (

--- a/components/layout/UserMenu.tsx
+++ b/components/layout/UserMenu.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { LogOut } from "lucide-react";
+import { ThemeToggle } from "./ThemeToggle";
 
 interface UserMenuProps {
   email: string;
@@ -27,6 +28,7 @@ export function UserMenu({ email, name }: UserMenuProps) {
         )}
         <p className="truncate text-xs text-muted-foreground">{email}</p>
       </div>
+      <ThemeToggle />
       <button
         onClick={handleSignOut}
         className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"

--- a/components/tasks/TaskBoardView.tsx
+++ b/components/tasks/TaskBoardView.tsx
@@ -31,7 +31,7 @@ function isPastDue(due: string | null, status: string) {
 
 function formatDate(d: string | null) {
   if (!d) return null;
-  return new Date(d).toLocaleDateString(undefined, {
+  return new Date(d).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
   });
@@ -80,7 +80,7 @@ export function TaskBoardView({ tasks }: { tasks: Task[] }) {
   );
 
   return (
-    <div className="grid grid-cols-4 gap-3 min-h-[400px]">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 min-h-[400px]">
       {COLUMNS.map((col) => {
         const colTasks = byStatus[col.id] ?? [];
         return (

--- a/components/tasks/TaskListView.tsx
+++ b/components/tasks/TaskListView.tsx
@@ -46,8 +46,8 @@ export function TaskListView({ tasks }: { tasks: Task[] }) {
   }
 
   return (
-    <div className="rounded-md border border-border">
-      <table className="w-full text-sm">
+    <div className="rounded-md border border-border overflow-x-auto">
+      <table className="w-full min-w-[640px] text-sm">
         <thead>
           <tr className="border-b border-border bg-muted/40">
             <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground w-20">ID</th>


### PR DESCRIPTION
Closes #6

## Summary

- **Dark mode toggle** — sun/moon button in sidebar footer; inline script prevents flash of wrong theme on load (respects `prefers-color-scheme` + `localStorage`)
- **Mobile sidebar** — `SidebarShell` client component adds hamburger + overlay on `< md` breakpoint; sidebar slides in from left
- **Loading skeletons** — content-shaped skeletons for `/clients`, `/invoices`, `/time`, `/time/list`, `/email-log`
- **Error boundaries** — `error.tsx` + `not-found.tsx` at `(admin)`, `portal/[tenantSlug]`, and root level
- **Email log page** — `/email-log` shows last 200 sent emails with type, recipient, subject, and sent/failed status; added to sidebar nav
- **Security** — upload limit reduced 20 MB → 10 MB; all three email API routes now require an authenticated session (task-closed and invoice require `admin` role)
- **Hydration fix** — `TaskBoardView.formatDate` was calling `toLocaleDateString(undefined)` causing server/client mismatch; pinned to `"en-US"`
- **Mobile tables** — `overflow-x-auto` + `min-w` on clients, tasks, and invoices tables; kanban board is single-column on mobile → 2 col on sm → 4 col on lg
- **README** — all phases marked complete; test commands and new features documented

## Test plan

- [x] `npm run build` passes (TypeScript clean)
- [x] `npm run test:unit` — 189 tests pass, 0 failures
- [ ] Toggle dark mode in sidebar footer → persists on reload
- [ ] Resize to mobile → hamburger appears, sidebar slides open
- [ ] `/email-log` shows empty state when no emails sent
- [ ] Upload file > 10 MB → 413 error
- [ ] Call `/api/email/task-closed` without auth → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)