### PR TITLE
feat: audit log description/resolution_notes, save/cancel editors

### DIFF
--- a/app/actions/audit.test.ts
+++ b/app/actions/audit.test.ts
@@ -81,4 +81,46 @@ describe("logTaskEvent", () => {
       })
     );
   });
+
+  it("accepts description_changed event type with snippet metadata", async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockSupabaseFrom.mockReturnValueOnce(chain);
+
+    await logTaskEvent({
+      tenantId: "t",
+      taskId: "tk",
+      actorId: "u",
+      actorRole: "admin",
+      eventType: "description_changed",
+      metadata: { snippet: "## Updated description" },
+    });
+
+    expect(chain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: "description_changed",
+        metadata: { snippet: "## Updated description" },
+      })
+    );
+  });
+
+  it("accepts resolution_notes_changed event type with snippet metadata", async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockSupabaseFrom.mockReturnValueOnce(chain);
+
+    await logTaskEvent({
+      tenantId: "t",
+      taskId: "tk",
+      actorId: "u",
+      actorRole: "admin",
+      eventType: "resolution_notes_changed",
+      metadata: { snippet: "Fixed by updating config" },
+    });
+
+    expect(chain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: "resolution_notes_changed",
+        metadata: { snippet: "Fixed by updating config" },
+      })
+    );
+  });
 });

--- a/app/actions/audit.ts
+++ b/app/actions/audit.ts
@@ -6,6 +6,8 @@ export type AuditEventType =
   | "created"
   | "status_changed"
   | "title_changed"
+  | "description_changed"
+  | "resolution_notes_changed"
   | "comment_added"
   | "attachment_added"
   | "attachment_deleted";

--- a/components/tasks/TaskAuditLog.tsx
+++ b/components/tasks/TaskAuditLog.tsx
@@ -9,6 +9,8 @@ import {
   Pencil,
   Trash2,
   PlusCircle,
+  AlignLeft,
+  StickyNote,
 } from "lucide-react";
 
 export interface AuditEntry {
@@ -57,6 +59,10 @@ function EntryIcon({ eventType }: { eventType: string }) {
       return <CheckCircle2 className={cls} />;
     case "title_changed":
       return <Pencil className={cls} />;
+    case "description_changed":
+      return <AlignLeft className={cls} />;
+    case "resolution_notes_changed":
+      return <StickyNote className={cls} />;
     case "comment_added":
       return <MessageSquare className={cls} />;
     case "attachment_added":
@@ -80,6 +86,10 @@ function entryDescription(entry: AuditEntry): string {
     }
     case "title_changed":
       return `${actor} renamed this task`;
+    case "description_changed":
+      return `${actor} updated the description`;
+    case "resolution_notes_changed":
+      return `${actor} updated the resolution notes`;
     case "comment_added":
       return `${actor} left a comment`;
     case "attachment_added": {

--- a/components/tasks/TaskEditors.tsx
+++ b/components/tasks/TaskEditors.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import { updateTaskContentAction } from "@/app/actions/tasks";
+import { Button } from "@/components/ui/button";
 
 const MilkdownEditor = dynamic(
   () => import("@/components/editor/MilkdownEditor"),
@@ -17,7 +18,7 @@ interface TaskEditorsProps {
   isClosed: boolean;
 }
 
-function AutoSaveEditor({
+function SaveCancelEditor({
   taskId,
   field,
   initialValue,
@@ -32,27 +33,55 @@ function AutoSaveEditor({
   placeholder?: string;
   readOnly?: boolean;
 }) {
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  // editorKey forces Milkdown to remount (and reset to savedValue) on cancel
+  const [editorKey, setEditorKey] = useState(0);
+  // savedValue tracks the last persisted value (may differ from SSR initialValue after a save)
+  const savedValue = useRef(initialValue);
+  const currentValue = useRef(initialValue);
 
-  const handleChange = useCallback(
-    (value: string) => {
-      if (saveTimer.current) clearTimeout(saveTimer.current);
-      saveTimer.current = setTimeout(async () => {
-        await updateTaskContentAction(taskId, field, value);
-      }, 1000);
-    },
-    [taskId, field]
-  );
+  const handleChange = useCallback((value: string) => {
+    currentValue.current = value;
+    setDirty(true);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    await updateTaskContentAction(taskId, field, currentValue.current);
+    savedValue.current = currentValue.current;
+    setSaving(false);
+    setDirty(false);
+  }, [taskId, field]);
+
+  const handleCancel = useCallback(() => {
+    currentValue.current = savedValue.current;
+    setEditorKey((k) => k + 1);
+    setDirty(false);
+  }, []);
 
   return (
-    <MilkdownEditor
-      value={initialValue}
-      onChange={readOnly ? undefined : handleChange}
-      uploadPath={readOnly ? undefined : uploadPath}
-      placeholder={placeholder}
-      readOnly={readOnly}
-      minHeight="140px"
-    />
+    <div className="space-y-2">
+      <MilkdownEditor
+        key={editorKey}
+        value={savedValue.current}
+        onChange={readOnly ? undefined : handleChange}
+        uploadPath={readOnly ? undefined : uploadPath}
+        placeholder={placeholder}
+        readOnly={readOnly}
+        minHeight="140px"
+      />
+      {dirty && !readOnly && (
+        <div className="flex items-center gap-2">
+          <Button size="sm" onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={handleCancel} disabled={saving}>
+            Cancel
+          </Button>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -71,7 +100,7 @@ export function TaskEditors({
         <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           Description
         </h2>
-        <AutoSaveEditor
+        <SaveCancelEditor
           taskId={taskId}
           field="description"
           initialValue={description}
@@ -85,7 +114,7 @@ export function TaskEditors({
         <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           Resolution notes
         </h2>
-        <AutoSaveEditor
+        <SaveCancelEditor
           taskId={taskId}
           field="resolution_notes"
           initialValue={resolutionNotes}

--- a/supabase/migrations/20260303000008_audit_log_content_fields.sql
+++ b/supabase/migrations/20260303000008_audit_log_content_fields.sql
@@ -1,0 +1,67 @@
+-- ============================================================
+-- Extend task audit log trigger to capture description and
+-- resolution_notes changes. Stores a short snippet (≤120 chars)
+-- in metadata rather than the full markdown content.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION log_task_mutation() RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_actor_id   UUID;
+  v_actor_role TEXT;
+BEGIN
+  v_actor_id   := auth.uid();
+  BEGIN
+    v_actor_role := auth_role();
+  EXCEPTION WHEN OTHERS THEN
+    v_actor_role := 'system';
+  END;
+  IF v_actor_role IS NULL THEN
+    v_actor_role := 'system';
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO task_audit_log
+      (tenant_id, task_id, actor_id, actor_role, event_type, new_value)
+    VALUES
+      (NEW.tenant_id, NEW.id, v_actor_id, v_actor_role, 'created', NEW.title);
+
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- Status change
+    IF OLD.status IS DISTINCT FROM NEW.status THEN
+      INSERT INTO task_audit_log
+        (tenant_id, task_id, actor_id, actor_role, event_type, old_value, new_value)
+      VALUES
+        (NEW.tenant_id, NEW.id, v_actor_id, v_actor_role, 'status_changed', OLD.status, NEW.status);
+    END IF;
+
+    -- Title change
+    IF OLD.title IS DISTINCT FROM NEW.title THEN
+      INSERT INTO task_audit_log
+        (tenant_id, task_id, actor_id, actor_role, event_type, old_value, new_value)
+      VALUES
+        (NEW.tenant_id, NEW.id, v_actor_id, v_actor_role, 'title_changed', OLD.title, NEW.title);
+    END IF;
+
+    -- Description change — store snippet of new value only
+    IF OLD.description IS DISTINCT FROM NEW.description THEN
+      INSERT INTO task_audit_log
+        (tenant_id, task_id, actor_id, actor_role, event_type, metadata)
+      VALUES
+        (NEW.tenant_id, NEW.id, v_actor_id, v_actor_role, 'description_changed',
+          jsonb_build_object('snippet', LEFT(COALESCE(NEW.description, ''), 120)));
+    END IF;
+
+    -- Resolution notes change — store snippet of new value only
+    IF OLD.resolution_notes IS DISTINCT FROM NEW.resolution_notes THEN
+      INSERT INTO task_audit_log
+        (tenant_id, task_id, actor_id, actor_role, event_type, metadata)
+      VALUES
+        (NEW.tenant_id, NEW.id, v_actor_id, v_actor_role, 'resolution_notes_changed',
+          jsonb_build_object('snippet', LEFT(COALESCE(NEW.resolution_notes, ''), 120)));
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary

- Extends the `log_task_mutation()` DB trigger to detect changes to `description` and `resolution_notes`, logging a 120-char snippet in `metadata` (no full markdown stored)
- Adds `description_changed` and `resolution_notes_changed` to `AuditEventType`; `TaskAuditLog` renders them with `AlignLeft`/`StickyNote` icons
- Replaces the auto-save debounce in `TaskEditors` with explicit **Save / Cancel** buttons that appear only when content is dirty; Cancel remounts Milkdown via `key` reset so it reverts to the last saved value

## Test plan

- [ ] Edit a task description, verify Save/Cancel buttons appear
- [ ] Save — confirm audit log shows "Consultant updated the description"
- [ ] Cancel — confirm editor resets to last saved content
- [ ] Same for resolution notes
- [ ] `npm run test:unit` passes (194 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)