### PR TITLE
feat: persistent formatting toolbar and UX improvements for task editors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -109,13 +109,16 @@
   border-radius: inherit;
 }
 
-/* Give the ProseMirror content area breathing room.
-   The 3.5rem left padding doubles as a gutter for the block drag-handle,
-   which is position:absolute and extends ~66px to the left of the content.
-   Without it the handle slides behind the fixed left nav (w-56 = 224px). */
+/* Compact padding — block handle is hidden on task editors so no left gutter needed. */
 .milkdown .ProseMirror {
-  padding: 0.5rem 0.75rem 0.5rem 3.5rem;
+  padding: 0.5rem 0.75rem;
   min-height: inherit;
+}
+
+/* Hide the block drag-handle and + button in task editors.
+   Slash commands (/) still work for inserting block types. */
+.crepe-editor-wrapper .milkdown-block-handle {
+  display: none;
 }
 
 /* Read-only: tint the background to signal non-editable state */

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { Crepe } from "@milkdown/crepe";
+import { commandsCtx } from "@milkdown/kit/core";
 import { cn } from "@/lib/utils";
 
 interface ToolbarConfig {
@@ -24,6 +25,7 @@ interface MilkdownEditorProps {
   minHeight?: string;
   className?: string;
   toolbarConfig?: ToolbarConfig;
+  onReady?: (callCommand: (key: string, payload?: unknown) => void) => void;
 }
 
 export function MilkdownEditor({
@@ -35,6 +37,7 @@ export function MilkdownEditor({
   minHeight = "120px",
   className,
   toolbarConfig,
+  onReady,
 }: MilkdownEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const crepeRef = useRef<Crepe | null>(null);
@@ -47,6 +50,7 @@ export function MilkdownEditor({
     const crepe = new Crepe({
       root: containerRef.current,
       defaultValue: value,
+      features: { [Crepe.Feature.Toolbar]: false },
       featureConfigs: {
         [Crepe.Feature.Placeholder]: { text: placeholder },
         ...(toolbarConfig ? { [Crepe.Feature.Toolbar]: toolbarConfig } : {}),
@@ -78,6 +82,11 @@ export function MilkdownEditor({
 
     crepe.create().then(() => {
       crepe.setReadonly(readOnly);
+      onReady?.((key, payload) => {
+        crepe.editor.action((ctx) => {
+          ctx.get(commandsCtx).call(key, payload);
+        });
+      });
     });
 
     crepeRef.current = crepe;

--- a/components/tasks/TaskEditors.tsx
+++ b/components/tasks/TaskEditors.tsx
@@ -1,9 +1,18 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useCallback, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { updateTaskContentAction } from "@/app/actions/tasks";
 import { Button } from "@/components/ui/button";
+import {
+  Bold,
+  Code,
+  Heading1,
+  Heading2,
+  Italic,
+  List,
+  ListOrdered,
+} from "lucide-react";
 
 const MilkdownEditor = dynamic(
   () => import("@/components/editor/MilkdownEditor"),
@@ -16,6 +25,51 @@ interface TaskEditorsProps {
   description: string;
   resolutionNotes: string;
   isClosed: boolean;
+}
+
+type CallCommand = (key: string, payload?: unknown) => void;
+
+const TOOLBAR_ITEMS: {
+  title: string;
+  icon: React.ReactNode;
+  command: () => Parameters<CallCommand>;
+}[] = [
+  { title: "Bold", icon: <Bold className="h-5 w-5" strokeWidth={2.5} />, command: () => ["ToggleStrong"] },
+  { title: "Italic", icon: <Italic className="h-5 w-5" />, command: () => ["ToggleEmphasis"] },
+  { title: "Inline code", icon: <Code className="h-5 w-5" />, command: () => ["ToggleInlineCode"] },
+  { title: "Heading 1", icon: <Heading1 className="h-5 w-5" />, command: () => ["WrapInHeading", 1] },
+  { title: "Heading 2", icon: <Heading2 className="h-5 w-5" />, command: () => ["WrapInHeading", 2] },
+  { title: "Bullet list", icon: <List className="h-5 w-5" />, command: () => ["WrapInBulletList"] },
+  { title: "Ordered list", icon: <ListOrdered className="h-5 w-5" />, command: () => ["WrapInOrderedList"] },
+];
+
+function EditorToolbar({ callCommandRef }: { callCommandRef: React.RefObject<CallCommand | null> }) {
+  return (
+    <div className="flex items-center border-b border-border bg-card px-1.5 py-1">
+      {TOOLBAR_ITEMS.map(({ title, icon, command }, i) => (
+        <React.Fragment key={title}>
+          {/* divider before headings and before lists */}
+          {(i === 3 || i === 5) && (
+            <div className="mx-2.5 h-6 w-px bg-border/60" />
+          )}
+          <button
+            title={title}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              callCommandRef.current?.(...command());
+            }}
+            className="m-1.5 flex h-8 w-8 items-center justify-center rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground active:bg-accent/70"
+          >
+            {icon}
+          </button>
+        </React.Fragment>
+      ))}
+      <div className="ml-auto flex items-center gap-1 pr-2 text-xs text-muted-foreground/50">
+        <kbd className="font-mono">/</kbd>
+        <span>for more</span>
+      </div>
+    </div>
+  );
 }
 
 function SaveCancelEditor({
@@ -33,6 +87,7 @@ function SaveCancelEditor({
   placeholder?: string;
   readOnly?: boolean;
 }) {
+  const [editing, setEditing] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   // editorKey forces Milkdown to remount (and reset to savedValue) on cancel
@@ -40,6 +95,11 @@ function SaveCancelEditor({
   // savedValue tracks the last persisted value (may differ from SSR initialValue after a save)
   const savedValue = useRef(initialValue);
   const currentValue = useRef(initialValue);
+  const callCommandRef = useRef<CallCommand | null>(null);
+
+  const handleReady = useCallback((fn: CallCommand) => {
+    callCommandRef.current = fn;
+  }, []);
 
   const handleChange = useCallback((value: string) => {
     currentValue.current = value;
@@ -52,32 +112,44 @@ function SaveCancelEditor({
     savedValue.current = currentValue.current;
     setSaving(false);
     setDirty(false);
+    setEditing(false);
   }, [taskId, field]);
 
   const handleCancel = useCallback(() => {
     currentValue.current = savedValue.current;
     setEditorKey((k) => k + 1);
     setDirty(false);
+    setEditing(false);
   }, []);
+
+  const isEditing = (editing || dirty) && !readOnly;
 
   return (
     <div className="space-y-2">
-      <MilkdownEditor
-        key={editorKey}
-        value={savedValue.current}
-        onChange={readOnly ? undefined : handleChange}
-        uploadPath={readOnly ? undefined : uploadPath}
-        placeholder={placeholder}
-        readOnly={readOnly}
-        minHeight="140px"
-      />
-      {dirty && !readOnly && (
-        <div className="flex items-center gap-2">
-          <Button size="sm" onClick={handleSave} disabled={saving}>
-            {saving ? "Saving…" : "Save"}
-          </Button>
+      <div
+        className="rounded-md border border-input ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
+        onFocus={() => !readOnly && setEditing(true)}
+      >
+        {isEditing && <EditorToolbar callCommandRef={callCommandRef} />}
+        <MilkdownEditor
+          key={editorKey}
+          value={savedValue.current}
+          onChange={readOnly ? undefined : handleChange}
+          uploadPath={readOnly ? undefined : uploadPath}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          minHeight="140px"
+          className={isEditing ? "rounded-t-none border-0 focus-within:ring-0" : "border-0 focus-within:ring-0"}
+          onReady={readOnly ? undefined : handleReady}
+        />
+      </div>
+      {isEditing && (
+        <div className="flex justify-end gap-2 pt-1">
           <Button size="sm" variant="ghost" onClick={handleCancel} disabled={saving}>
             Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
           </Button>
         </div>
       )}
@@ -105,7 +177,7 @@ export function TaskEditors({
           field="description"
           initialValue={description}
           uploadPath={uploadPath}
-          placeholder="Add a description… (paste or drag images to upload)"
+          placeholder=""
           readOnly={isClosed}
         />
       </div>
@@ -119,7 +191,7 @@ export function TaskEditors({
           field="resolution_notes"
           initialValue={resolutionNotes}
           uploadPath={uploadPath}
-          placeholder="Document the resolution… (always editable)"
+          placeholder=""
         />
       </div>
     </div>


### PR DESCRIPTION
- Add fixed formatting toolbar (Bold, Italic, Code, H1, H2, Bullet, Ordered list) with slash command hint; toolbar and save/cancel only appear in edit mode
- Expose callCommand via onReady callback in MilkdownEditor so toolbar buttons dispatch Milkdown commands without stealing editor focus (onMouseDown + preventDefault)
- Disable Crepe's floating selection toolbar in favour of the fixed toolbar
- Hide Milkdown block drag-handle/+ button; reduce ProseMirror left padding to 0.75rem
- Save/Cancel buttons moved below editor box (justify-end row) instead of floating overlay
- Show save/cancel + toolbar as soon as editor receives focus, not only after a change