### PR TITLE
feat: replace Supabase invite flow with OTP magic-link-only portal access

### DIFF
--- a/app/actions/portal.test.ts
+++ b/app/actions/portal.test.ts
@@ -9,6 +9,15 @@ import {
   resetSupabaseMocks,
 } from "@/lib/supabase/__mocks__";
 
+// Hoist the Resend mock so it's available before vi.mock hoisting
+const mockEmailsSend = vi.hoisted(() => vi.fn());
+
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: mockEmailsSend };
+  },
+}));
+
 vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
 vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
@@ -17,47 +26,27 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { revalidatePath } from "next/cache";
 import {
-  inviteClientToPortalAction,
   sendPortalSignInLinkAction,
   revokePortalAccessAction,
-  finalizeInviteAction,
 } from "@/app/actions/portal";
 
 const adminUser = { id: "admin-1", app_metadata: { role: "admin" } };
-const portalUser = {
-  id: "portal-1",
-  email: "client@example.com",
-  app_metadata: { role: "client", tenant_slug: "acme" },
-  user_metadata: { tenant_id: "t1", client_id: "c1" },
-};
 
 beforeEach(() => {
   resetSupabaseMocks();
   (createClient as Mock).mockResolvedValue(mockSupabaseClient);
   (createAdminClient as Mock).mockReturnValue(mockAdminClient);
+  mockEmailsSend.mockReset();
+  process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+  process.env.RESEND_API_KEY = "test-key";
 });
 
-// ── inviteClientToPortalAction ─────────────────────────────────────────────
+// ── sendPortalSignInLinkAction ─────────────────────────────────────────────
 
-describe("inviteClientToPortalAction", () => {
-  const makeFormData = (email: string) => {
-    const fd = new FormData();
-    fd.append("email", email);
-    return fd;
-  };
-
+describe("sendPortalSignInLinkAction", () => {
   it("returns Unauthorized when no user", async () => {
-    const result = await inviteClientToPortalAction("c1", null, makeFormData("a@b.com"));
+    const result = await sendPortalSignInLinkAction("c1", null);
     expect(result).toEqual({ error: "Unauthorized." });
-  });
-
-  it("returns error when email is empty", async () => {
-    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
-      data: { user: adminUser },
-      error: null,
-    });
-    const result = await inviteClientToPortalAction("c1", null, makeFormData(""));
-    expect(result).toEqual({ error: "Email is required." });
   });
 
   it("returns Unauthorized when profile role is not admin", async () => {
@@ -68,68 +57,6 @@ describe("inviteClientToPortalAction", () => {
     mockSupabaseFrom.mockReturnValueOnce(
       makeChain({ data: { tenant_id: "t1", role: "client" }, error: null })
     );
-    const result = await inviteClientToPortalAction("c1", null, makeFormData("x@y.com"));
-    expect(result).toEqual({ error: "Unauthorized." });
-  });
-
-  it("returns error when client not found", async () => {
-    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
-      data: { user: adminUser },
-      error: null,
-    });
-    mockSupabaseFrom
-      .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: null, error: null })); // client not found
-
-    const result = await inviteClientToPortalAction("c1", null, makeFormData("x@y.com"));
-    expect(result).toEqual({ error: "Client not found." });
-  });
-
-  it("returns error from admin invite call", async () => {
-    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
-      data: { user: adminUser },
-      error: null,
-    });
-    mockSupabaseFrom
-      .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: { id: "c1" }, error: null }));
-    mockAdminAuthAdmin.inviteUserByEmail.mockResolvedValueOnce({
-      data: null,
-      error: { message: "already invited" },
-    });
-
-    const result = await inviteClientToPortalAction("c1", null, makeFormData("x@y.com"));
-    expect(result).toEqual({ error: "already invited" });
-  });
-
-  it("invites client successfully", async () => {
-    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
-      data: { user: adminUser },
-      error: null,
-    });
-    mockSupabaseFrom
-      .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: { id: "c1" }, error: null }));
-    mockAdminAuthAdmin.inviteUserByEmail.mockResolvedValueOnce({
-      data: {},
-      error: null,
-    });
-
-    const result = await inviteClientToPortalAction("c1", null, makeFormData("client@example.com"));
-    expect(result).toEqual({ success: true });
-    expect(mockAdminAuthAdmin.inviteUserByEmail).toHaveBeenCalledWith(
-      "client@example.com",
-      expect.objectContaining({
-        data: expect.objectContaining({ role: "client", tenant_id: "t1", client_id: "c1" }),
-      })
-    );
-  });
-});
-
-// ── sendPortalSignInLinkAction ─────────────────────────────────────────────
-
-describe("sendPortalSignInLinkAction", () => {
-  it("returns Unauthorized when no user", async () => {
     const result = await sendPortalSignInLinkAction("c1", null);
     expect(result).toEqual({ error: "Unauthorized." });
   });
@@ -141,45 +68,172 @@ describe("sendPortalSignInLinkAction", () => {
     });
     mockSupabaseFrom
       .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: { email: null }, error: null }));
+      .mockReturnValueOnce(makeChain({ data: { email: null, name: "Bob" }, error: null }));
 
     const result = await sendPortalSignInLinkAction("c1", null);
     expect(result).toEqual({ error: "Client email not found." });
   });
 
-  it("returns error when no portal access", async () => {
+  it("returns error when tenant not found", async () => {
     mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
       data: { user: adminUser },
       error: null,
     });
     mockSupabaseFrom
       .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: { email: "c@example.com" }, error: null }));
+      .mockReturnValueOnce(makeChain({ data: { email: "c@example.com", name: "Bob" }, error: null }));
     mockAdminFrom
-      .mockReturnValueOnce(makeChain({ data: null, error: null })); // no portal access
+      .mockReturnValueOnce(makeChain({ data: null, error: null })); // tenant not found
 
     const result = await sendPortalSignInLinkAction("c1", null);
-    expect(result).toEqual({ error: "Client does not have portal access." });
+    expect(result).toEqual({ error: "Tenant not found." });
   });
 
-  it("sends magic link successfully", async () => {
+  it("inserts pending portal_access row on first grant", async () => {
     mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
       data: { user: adminUser },
       error: null,
     });
     mockSupabaseFrom
       .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: { email: "c@example.com" }, error: null }));
+      .mockReturnValueOnce(makeChain({ data: { email: "c@example.com", name: "Bob" }, error: null }));
+
+    const insertAccessChain = makeChain({ data: null, error: null });
+    const insertEmailLogChain = makeChain({ data: null, error: null });
+
     mockAdminFrom
-      .mockReturnValueOnce(makeChain({ data: { user_id: "u1" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: { slug: "acme" }, error: null }));
-    mockSupabaseClient.auth.signInWithOtp.mockResolvedValueOnce({ error: null });
+      .mockReturnValueOnce(makeChain({ data: { slug: "acme" }, error: null }))      // tenant
+      .mockReturnValueOnce(makeChain({ data: { business_name: "Acme Co" }, error: null })) // settings
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))                  // no existing access
+      .mockReturnValueOnce(insertAccessChain)                                       // insert access row
+      .mockReturnValueOnce(insertEmailLogChain);                                    // email_log insert
+
+    mockAdminAuthAdmin.generateLink.mockResolvedValueOnce({
+      data: { properties: { action_link: "https://supabase.co/magic-link" } },
+      error: null,
+    });
+    mockEmailsSend.mockResolvedValueOnce({ data: { id: "resend-1" }, error: null });
 
     const result = await sendPortalSignInLinkAction("c1", null);
     expect(result).toEqual({ success: true });
-    expect(mockSupabaseClient.auth.signInWithOtp).toHaveBeenCalledWith(
-      expect.objectContaining({ email: "c@example.com" })
+    expect(insertAccessChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ client_id: "c1", tenant_id: "t1", invited_at: expect.any(String) })
     );
+  });
+
+  it("skips row insertion on resend (row already exists)", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: adminUser },
+      error: null,
+    });
+    mockSupabaseFrom
+      .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { email: "c@example.com", name: "Bob" }, error: null }));
+
+    const insertEmailLogChain = makeChain({ data: null, error: null });
+
+    mockAdminFrom
+      .mockReturnValueOnce(makeChain({ data: { slug: "acme" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { business_name: "Acme Co" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { id: "existing-row" }, error: null })) // existing access
+      .mockReturnValueOnce(insertEmailLogChain);                                     // email_log insert
+
+    mockAdminAuthAdmin.generateLink.mockResolvedValueOnce({
+      data: { properties: { action_link: "https://supabase.co/magic-link" } },
+      error: null,
+    });
+    mockEmailsSend.mockResolvedValueOnce({ data: { id: "resend-1" }, error: null });
+
+    const result = await sendPortalSignInLinkAction("c1", null);
+    expect(result).toEqual({ success: true });
+    // Only 4 admin.from calls (tenant, settings, existing check, email_log) — no insert
+    expect(mockAdminFrom).toHaveBeenCalledTimes(4);
+  });
+
+  it("sends branded Resend email with magic link", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: adminUser },
+      error: null,
+    });
+    mockSupabaseFrom
+      .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { email: "c@example.com", name: "Bob" }, error: null }));
+    mockAdminFrom
+      .mockReturnValueOnce(makeChain({ data: { slug: "acme" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { business_name: "Acme Co" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))  // no existing access
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))  // insert access
+      .mockReturnValueOnce(makeChain({ data: null, error: null })); // email_log
+    mockAdminAuthAdmin.generateLink.mockResolvedValueOnce({
+      data: { properties: { action_link: "https://supabase.co/magic-link-url" } },
+      error: null,
+    });
+    mockEmailsSend.mockResolvedValueOnce({ data: { id: "r-1" }, error: null });
+
+    await sendPortalSignInLinkAction("c1", null);
+
+    expect(mockAdminAuthAdmin.generateLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "magiclink",
+        email: "c@example.com",
+        options: expect.objectContaining({ redirectTo: expect.stringContaining("/portal/acme") }),
+      })
+    );
+
+    const [emailArgs] = mockEmailsSend.mock.calls[0];
+    expect(emailArgs.to).toBe("c@example.com");
+    expect(emailArgs.subject).toContain("Acme Co");
+    expect(emailArgs.html).toContain("https://supabase.co/magic-link-url");
+    expect(emailArgs.html).toContain("Bob");
+  });
+
+  it("returns error when generateLink fails", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: adminUser },
+      error: null,
+    });
+    mockSupabaseFrom
+      .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { email: "c@example.com", name: "Bob" }, error: null }));
+    mockAdminFrom
+      .mockReturnValueOnce(makeChain({ data: { slug: "acme" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { business_name: "Acme Co" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))  // no existing access
+      .mockReturnValueOnce(makeChain({ data: null, error: null })); // insert access
+    mockAdminAuthAdmin.generateLink.mockResolvedValueOnce({
+      data: null,
+      error: { message: "rate limited" },
+    });
+
+    const result = await sendPortalSignInLinkAction("c1", null);
+    expect(result).toEqual({ error: "rate limited" });
+  });
+
+  it("returns error when Resend send fails", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: adminUser },
+      error: null,
+    });
+    mockSupabaseFrom
+      .mockReturnValueOnce(makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { email: "c@example.com", name: "Bob" }, error: null }));
+    mockAdminFrom
+      .mockReturnValueOnce(makeChain({ data: { slug: "acme" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { business_name: "Acme Co" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))  // no existing access
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))  // insert access
+      .mockReturnValueOnce(makeChain({ data: null, error: null })); // email_log
+    mockAdminAuthAdmin.generateLink.mockResolvedValueOnce({
+      data: { properties: { action_link: "https://supabase.co/magic" } },
+      error: null,
+    });
+    mockEmailsSend.mockResolvedValueOnce({
+      data: null,
+      error: { message: "Resend error" },
+    });
+
+    const result = await sendPortalSignInLinkAction("c1", null);
+    expect(result).toEqual({ error: "Resend error" });
   });
 });
 
@@ -205,7 +259,7 @@ describe("revokePortalAccessAction", () => {
     expect(result).toEqual({ error: "No portal access found." });
   });
 
-  it("revokes access: deletes profile, access record, and auth user", async () => {
+  it("revokes access when client has signed up: deletes profile, access record, and auth user", async () => {
     mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
       data: { user: adminUser },
       error: null,
@@ -229,68 +283,26 @@ describe("revokePortalAccessAction", () => {
     expect(mockAdminAuthAdmin.deleteUser).toHaveBeenCalledWith("portal-user-1");
     expect(revalidatePath).toHaveBeenCalledWith("/clients/c1");
   });
-});
 
-// ── finalizeInviteAction ───────────────────────────────────────────────────
-
-describe("finalizeInviteAction", () => {
-  it("returns error when not authenticated", async () => {
-    const result = await finalizeInviteAction();
-    expect(result).toEqual({ error: "Not authenticated." });
-  });
-
-  it("returns slug for existing client profile", async () => {
+  it("revokes access when client was invited but never signed up (user_id null)", async () => {
     mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
-      data: { user: portalUser },
+      data: { user: adminUser },
       error: null,
     });
     mockSupabaseFrom.mockReturnValueOnce(
-      makeChain({ data: { role: "client" }, error: null })
+      makeChain({ data: { tenant_id: "t1", role: "admin" }, error: null })
     );
-
-    const result = await finalizeInviteAction();
-    expect(result).toEqual({ slug: "acme" });
-  });
-
-  it("returns error when tenant_id or client_id missing in metadata", async () => {
-    const userNoMeta = { id: "u1", app_metadata: {}, user_metadata: {} };
-    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
-      data: { user: userNoMeta },
-      error: null,
-    });
-    mockSupabaseFrom.mockReturnValueOnce(makeChain({ data: null, error: null }));
-
-    const result = await finalizeInviteAction();
-    expect(result).toEqual({ error: "Invalid invite." });
-  });
-
-  it("creates profile + portal access for new invite user", async () => {
-    const inviteUser = {
-      id: "new-user",
-      email: "new@example.com",
-      app_metadata: {},
-      user_metadata: { tenant_id: "t1", client_id: "c1" },
-    };
-    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
-      data: { user: inviteUser },
-      error: null,
-    });
-    // no existing profile
-    mockSupabaseFrom.mockReturnValueOnce(makeChain({ data: null, error: null }));
-    // admin: tenant lookup
+    const accessChain = makeChain({ data: { user_id: null }, error: null });
+    const deleteAccessChain = makeChain({ data: null, error: null });
     mockAdminFrom
-      .mockReturnValueOnce(makeChain({ data: { slug: "acme" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: null, error: null })) // profiles insert
-      .mockReturnValueOnce(makeChain({ data: null, error: null })); // portal_access insert
-    mockAdminAuthAdmin.updateUserById.mockResolvedValueOnce({ error: null });
+      .mockReturnValueOnce(accessChain)
+      .mockReturnValueOnce(deleteAccessChain);
 
-    const result = await finalizeInviteAction();
-    expect(result).toEqual({ slug: "acme" });
-    expect(mockAdminAuthAdmin.updateUserById).toHaveBeenCalledWith(
-      "new-user",
-      expect.objectContaining({
-        app_metadata: expect.objectContaining({ role: "client", tenant_slug: "acme" }),
-      })
-    );
+    const result = await revokePortalAccessAction("c1");
+    expect(result).toEqual({ success: true });
+    // No profile delete or auth user delete when user_id is null
+    expect(mockAdminAuthAdmin.deleteUser).not.toHaveBeenCalled();
+    expect(deleteAccessChain.delete).toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalledWith("/clients/c1");
   });
 });

--- a/app/actions/portal.ts
+++ b/app/actions/portal.ts
@@ -1,110 +1,26 @@
 "use server";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { Resend } from "resend";
 
-export async function inviteClientToPortalAction(
-  clientId: string,
-  _prev: { error?: string; success?: boolean } | null,
-  formData: FormData
-): Promise<{ error?: string; success?: boolean }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return { error: "Unauthorized." };
-
-  const email = (formData.get("email") as string)?.trim();
-  if (!email) return { error: "Email is required." };
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("tenant_id, role")
-    .eq("id", user.id)
-    .single();
-  if (!profile || profile.role !== "admin") return { error: "Unauthorized." };
-
-  const { data: client } = await supabase
-    .from("clients")
-    .select("id")
-    .eq("id", clientId)
-    .single();
-  if (!client) return { error: "Client not found." };
-
-  const admin = createAdminClient();
-  const { error } = await admin.auth.admin.inviteUserByEmail(email, {
-    data: { role: "client", tenant_id: profile.tenant_id, client_id: clientId },
-    redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/accept-invite`,
-  });
-
-  if (error) return { error: error.message };
-  return { success: true };
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
-export async function finalizeInviteAction(): Promise<{
-  error?: string;
-  slug?: string;
-}> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return { error: "Not authenticated." };
-
-  // Already has a profile — just return the slug
-  const { data: existingProfile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (existingProfile?.role === "client") {
-    const slug = user.app_metadata?.tenant_slug as string | undefined;
-    return slug ? { slug } : { error: "Missing tenant slug." };
-  }
-
-  // New client — create profile + portal access
-  const tenantId = user.user_metadata?.tenant_id as string | undefined;
-  const clientId = user.user_metadata?.client_id as string | undefined;
-  if (!tenantId || !clientId) return { error: "Invalid invite." };
-
-  const admin = createAdminClient();
-  const { data: tenant } = await admin
-    .from("tenants")
-    .select("slug")
-    .eq("id", tenantId)
-    .single();
-  if (!tenant) return { error: "Tenant not found." };
-
-  const { error: profileError } = await admin.from("profiles").insert({
-    id: user.id,
-    tenant_id: tenantId,
-    role: "client",
-    full_name:
-      (user.user_metadata?.full_name as string | undefined) ??
-      user.email?.split("@")[0] ??
-      "Client",
-  });
-  if (profileError) return { error: profileError.message };
-
-  await admin.from("client_portal_access").insert({
-    tenant_id: tenantId,
-    client_id: clientId,
-    user_id: user.id,
-    invited_at: new Date().toISOString(),
-    accepted_at: new Date().toISOString(),
-  });
-
-  await admin.auth.admin.updateUserById(user.id, {
-    app_metadata: {
-      role: "client",
-      tenant_id: tenantId,
-      tenant_slug: tenant.slug,
-    },
-  });
-
-  return { slug: tenant.slug };
-}
-
+/**
+ * Grant portal access to a client (first invite) OR resend an access link.
+ *
+ * On first call: creates a pending client_portal_access row (invited_at set,
+ * user_id + accepted_at null), generates a magic link via the Supabase admin
+ * API, and sends a branded invite email via Resend.
+ *
+ * On subsequent calls (resend): skips row creation and just regenerates a new
+ * magic link + sends the email again.
+ */
 export async function sendPortalSignInLinkAction(
   clientId: string,
   _prev: { error?: string; success?: boolean } | null
@@ -122,22 +38,14 @@ export async function sendPortalSignInLinkAction(
     .single();
   if (!profile || profile.role !== "admin") return { error: "Unauthorized." };
 
-  // Get client email and portal access
   const { data: client } = await supabase
     .from("clients")
-    .select("email")
+    .select("email, name")
     .eq("id", clientId)
     .single();
   if (!client?.email) return { error: "Client email not found." };
 
   const admin = createAdminClient();
-  const { data: access } = await admin
-    .from("client_portal_access")
-    .select("user_id")
-    .eq("client_id", clientId)
-    .eq("tenant_id", profile.tenant_id)
-    .single();
-  if (!access) return { error: "Client does not have portal access." };
 
   const { data: tenant } = await admin
     .from("tenants")
@@ -146,14 +54,81 @@ export async function sendPortalSignInLinkAction(
     .single();
   if (!tenant) return { error: "Tenant not found." };
 
-  const { error } = await supabase.auth.signInWithOtp({
+  const { data: settings } = await admin
+    .from("tenant_settings")
+    .select("business_name")
+    .eq("tenant_id", profile.tenant_id)
+    .maybeSingle();
+  const businessName = (settings?.business_name as string | null) ?? "Your consultant";
+
+  // Insert pending access row on first grant; skip on resend
+  const { data: existingAccess } = await admin
+    .from("client_portal_access")
+    .select("id")
+    .eq("client_id", clientId)
+    .eq("tenant_id", profile.tenant_id)
+    .maybeSingle();
+
+  if (!existingAccess) {
+    await admin.from("client_portal_access").insert({
+      tenant_id: profile.tenant_id,
+      client_id: clientId,
+      invited_at: new Date().toISOString(),
+      // user_id and accepted_at are intentionally null — populated on first login
+    });
+  }
+
+  // Generate magic link without sending Supabase's default email
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+  const { data: linkData, error: linkError } = await admin.auth.admin.generateLink({
+    type: "magiclink",
     email: client.email,
     options: {
-      emailRedirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback?next=/portal/${tenant.slug}`,
+      redirectTo: `${appUrl}/auth/callback?next=/portal/${tenant.slug}`,
     },
   });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const actionLink = (linkData as any)?.properties?.action_link as string | undefined;
+  if (linkError || !actionLink) {
+    return { error: (linkError as Error | null)?.message ?? "Failed to generate sign-in link." };
+  }
 
-  if (error) return { error: error.message };
+  // Send branded invite email via Resend
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const clientName = (client.name as string | null) ?? "there";
+  const subject = `Your ${businessName} portal is ready`;
+  const html = `
+    <p>Hi ${escapeHtml(clientName)},</p>
+    <p>${escapeHtml(businessName)} has given you access to your client portal.</p>
+    <p style="margin:24px 0">
+      <a href="${actionLink}" style="background:#0969da;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600">
+        Access your portal
+      </a>
+    </p>
+    <p style="color:#6e7781;font-size:12px">
+      This link expires in 1 hour. If you did not expect this email, you can ignore it.
+    </p>
+  `;
+
+  const { data: sendData, error: sendError } = await resend.emails.send({
+    from: `${businessName} <noreply@${process.env.RESEND_DOMAIN ?? "taskflow.dev"}>`,
+    to: client.email,
+    subject,
+    html,
+  });
+
+  await admin.from("email_log").insert({
+    tenant_id: profile.tenant_id,
+    to_email: client.email,
+    subject,
+    type: "portal_invite",
+    related_id: clientId,
+    resend_id: sendData?.id ?? null,
+    status: sendError ? "failed" : "sent",
+    error_message: (sendError as Error | null)?.message ?? null,
+  });
+
+  if (sendError) return { error: (sendError as Error).message };
   return { success: true };
 }
 
@@ -182,15 +157,19 @@ export async function revokePortalAccessAction(
     .single();
   if (!access) return { error: "No portal access found." };
 
-  const userId = access.user_id as string;
+  const userId = access.user_id as string | null;
 
-  await admin.from("profiles").delete().eq("id", userId);
+  // Only clean up auth user + profile if the client has actually signed up
+  if (userId) {
+    await admin.from("profiles").delete().eq("id", userId);
+    await admin.auth.admin.deleteUser(userId);
+  }
+
   await admin
     .from("client_portal_access")
     .delete()
     .eq("client_id", clientId)
     .eq("tenant_id", profile.tenant_id);
-  await admin.auth.admin.deleteUser(userId);
 
   const { revalidatePath } = await import("next/cache");
   revalidatePath(`/clients/${clientId}`);

--- a/app/api/email/portal-invite/portal-invite.test.ts
+++ b/app/api/email/portal-invite/portal-invite.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────
+
+const mockEmailsSend = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+const mockGetUser = vi.hoisted(() => vi.fn());
+const mockGenerateLink = vi.hoisted(() => vi.fn());
+
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: mockEmailsSend };
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => Promise.resolve({ auth: { getUser: mockGetUser } }),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: mockFrom,
+    auth: { admin: { generateLink: mockGenerateLink } },
+  }),
+}));
+
+const adminUser = { id: "admin-1", app_metadata: { role: "admin" } };
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost:3000/api/email/portal-invite", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockSingle(data: unknown) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data, error: data ? null : { message: "not found" } }),
+    maybeSingle: vi.fn().mockResolvedValue({ data, error: null }),
+  };
+}
+
+function mockEmailLogInsert() {
+  return { insert: vi.fn().mockResolvedValue({ data: {}, error: null }) };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("POST /api/email/portal-invite", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mockGetUser.mockResolvedValue({ data: { user: adminUser } });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ clientId: "c1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when user is not an admin", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u2", app_metadata: { role: "client" } } },
+    });
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ clientId: "c1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when clientId is missing", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/missing clientId/i);
+  });
+
+  it("returns 404 when client is not found", async () => {
+    mockFrom
+      .mockReturnValueOnce(mockSingle({ tenant_id: "t1" })) // admin profile
+      .mockReturnValueOnce(mockSingle(null));                 // client not found
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ clientId: "nonexistent" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns {skipped:true} when client has no email", async () => {
+    mockFrom
+      .mockReturnValueOnce(mockSingle({ tenant_id: "t1" }))
+      .mockReturnValueOnce(mockSingle({ email: null, name: "Bob", tenant_id: "t1" }));
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ clientId: "c1" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.skipped).toBe(true);
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
+
+  it("returns {sent:true} and logs email on success", async () => {
+    mockFrom
+      .mockReturnValueOnce(mockSingle({ tenant_id: "t1" }))
+      .mockReturnValueOnce(
+        mockSingle({ email: "client@example.com", name: "Alice", tenant_id: "t1" })
+      )
+      .mockReturnValueOnce(mockSingle({ slug: "acme" }))
+      .mockReturnValueOnce(mockSingle({ business_name: "Acme Co" }))
+      .mockReturnValueOnce(mockEmailLogInsert());
+
+    mockGenerateLink.mockResolvedValueOnce({
+      data: { properties: { action_link: "https://magic-link-url.example.com" } },
+      error: null,
+    });
+    mockEmailsSend.mockResolvedValueOnce({ data: { id: "resend-abc" }, error: null });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ clientId: "c1" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.sent).toBe(true);
+
+    const [emailArgs] = mockEmailsSend.mock.calls[0];
+    expect(emailArgs.to).toBe("client@example.com");
+    expect(emailArgs.subject).toContain("Acme Co");
+    expect(emailArgs.html).toContain("https://magic-link-url.example.com");
+    expect(emailArgs.html).toContain("Alice");
+  });
+
+  it("returns 500 when generateLink fails", async () => {
+    mockFrom
+      .mockReturnValueOnce(mockSingle({ tenant_id: "t1" }))
+      .mockReturnValueOnce(
+        mockSingle({ email: "client@example.com", name: "Alice", tenant_id: "t1" })
+      )
+      .mockReturnValueOnce(mockSingle({ slug: "acme" }))
+      .mockReturnValueOnce(mockSingle({ business_name: "Acme Co" }));
+
+    mockGenerateLink.mockResolvedValueOnce({
+      data: null,
+      error: { message: "token generation failed" },
+    });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ clientId: "c1" }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/token generation failed/i);
+  });
+
+  it("returns 500 and logs failure when Resend send fails", async () => {
+    mockFrom
+      .mockReturnValueOnce(mockSingle({ tenant_id: "t1" }))
+      .mockReturnValueOnce(
+        mockSingle({ email: "client@example.com", name: "Alice", tenant_id: "t1" })
+      )
+      .mockReturnValueOnce(mockSingle({ slug: "acme" }))
+      .mockReturnValueOnce(mockSingle({ business_name: "Acme Co" }))
+      .mockReturnValueOnce(mockEmailLogInsert());
+
+    mockGenerateLink.mockResolvedValueOnce({
+      data: { properties: { action_link: "https://magic.example.com" } },
+      error: null,
+    });
+    mockEmailsSend.mockResolvedValueOnce({
+      data: null,
+      error: { message: "Rate limit exceeded" },
+    });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest({ clientId: "c1" }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/rate limit/i);
+  });
+
+  it("escapes HTML in client name and business name", async () => {
+    mockFrom
+      .mockReturnValueOnce(mockSingle({ tenant_id: "t1" }))
+      .mockReturnValueOnce(
+        mockSingle({ email: "client@example.com", name: "<b>Bob</b>", tenant_id: "t1" })
+      )
+      .mockReturnValueOnce(mockSingle({ slug: "acme" }))
+      .mockReturnValueOnce(mockSingle({ business_name: "<Acme & Co>" }))
+      .mockReturnValueOnce(mockEmailLogInsert());
+
+    mockGenerateLink.mockResolvedValueOnce({
+      data: { properties: { action_link: "https://magic.example.com" } },
+      error: null,
+    });
+    mockEmailsSend.mockResolvedValueOnce({ data: { id: "r-1" }, error: null });
+
+    const { POST } = await import("./route");
+    await POST(makeRequest({ clientId: "c1" }));
+
+    const [emailArgs] = mockEmailsSend.mock.calls[0];
+    expect(emailArgs.html).not.toContain("<b>Bob</b>");
+    expect(emailArgs.html).toContain("&lt;b&gt;Bob&lt;/b&gt;");
+    expect(emailArgs.html).toContain("&lt;Acme &amp; Co&gt;");
+  });
+});

--- a/app/api/email/portal-invite/route.ts
+++ b/app/api/email/portal-invite/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export async function POST(request: NextRequest) {
+  const caller = await createClient();
+  const {
+    data: { user },
+  } = await caller.auth.getUser();
+  if (!user || user.app_metadata?.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { clientId } = await request.json();
+  if (!clientId) {
+    return NextResponse.json({ error: "Missing clientId" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+
+  // Get admin's tenant
+  const { data: adminProfile } = await admin
+    .from("profiles")
+    .select("tenant_id")
+    .eq("id", user.id)
+    .single();
+  if (!adminProfile) {
+    return NextResponse.json({ error: "Admin profile not found" }, { status: 404 });
+  }
+
+  // Fetch client + tenant info
+  const { data: client, error: clientError } = await admin
+    .from("clients")
+    .select("email, name, tenant_id")
+    .eq("id", clientId)
+    .eq("tenant_id", adminProfile.tenant_id)
+    .single();
+
+  if (clientError || !client) {
+    return NextResponse.json({ error: "Client not found" }, { status: 404 });
+  }
+
+  if (!client.email) {
+    return NextResponse.json({ skipped: true });
+  }
+
+  const { data: tenant } = await admin
+    .from("tenants")
+    .select("slug")
+    .eq("id", client.tenant_id)
+    .single();
+  if (!tenant) {
+    return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+  }
+
+  const { data: settings } = await admin
+    .from("tenant_settings")
+    .select("business_name")
+    .eq("tenant_id", client.tenant_id)
+    .maybeSingle();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const businessName = ((settings as any)?.business_name as string | null) ?? "Your consultant";
+
+  // Generate magic link
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+  const { data: linkData, error: linkError } = await admin.auth.admin.generateLink({
+    type: "magiclink",
+    email: client.email,
+    options: {
+      redirectTo: `${appUrl}/auth/callback?next=/portal/${tenant.slug}`,
+    },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const actionLink = (linkData as any)?.properties?.action_link as string | undefined;
+  if (linkError || !actionLink) {
+    return NextResponse.json(
+      { error: (linkError as Error | null)?.message ?? "Failed to generate sign-in link" },
+      { status: 500 }
+    );
+  }
+
+  const clientName = (client.name as string | null) ?? "there";
+  const subject = `Your ${businessName} portal is ready`;
+  const html = `
+    <p>Hi ${escapeHtml(clientName)},</p>
+    <p>${escapeHtml(businessName)} has given you access to your client portal.</p>
+    <p style="margin:24px 0">
+      <a href="${actionLink}" style="background:#0969da;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600">
+        Access your portal
+      </a>
+    </p>
+    <p style="color:#6e7781;font-size:12px">
+      This link expires in 1 hour. If you did not expect this email, you can ignore it.
+    </p>
+  `;
+
+  const { data: sendData, error: sendError } = await resend.emails.send({
+    from: `${businessName} <noreply@${process.env.RESEND_DOMAIN ?? "taskflow.dev"}>`,
+    to: client.email,
+    subject,
+    html,
+  });
+
+  await admin.from("email_log").insert({
+    tenant_id: client.tenant_id,
+    to_email: client.email,
+    subject,
+    type: "portal_invite",
+    related_id: clientId,
+    resend_id: sendData?.id ?? null,
+    status: sendError ? "failed" : "sent",
+    error_message: (sendError as Error | null)?.message ?? null,
+  });
+
+  if (sendError) {
+    return NextResponse.json({ error: (sendError as Error).message }, { status: 500 });
+  }
+
+  return NextResponse.json({ sent: true });
+}

--- a/app/auth/accept-invite/page.tsx
+++ b/app/auth/accept-invite/page.tsx
@@ -1,67 +1,8 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { createClient } from "@/lib/supabase/client";
-import { finalizeInviteAction } from "@/app/actions/portal";
-
+// This route was used by the old Supabase inviteUserByEmail flow which has
+// been replaced by the OTP magic-link flow. Incoming requests are redirected
+// to the login page.
 export default function AcceptInvitePage() {
-  const router = useRouter();
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function handle() {
-      const supabase = createClient();
-
-      // Supabase JS client automatically processes the #access_token hash
-      // and stores the session in cookies before getSession() resolves.
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-
-      if (!session) {
-        setError("Authentication failed. Please try the invite link again.");
-        return;
-      }
-
-      const result = await finalizeInviteAction();
-
-      if (result.error) {
-        setError(result.error);
-        return;
-      }
-
-      // Refresh session so the updated app_metadata (role + tenant_slug)
-      // is reflected in the JWT before the portal redirect hits proxy.ts.
-      await supabase.auth.refreshSession();
-
-      if (result.slug) {
-        router.replace(`/portal/${result.slug}`);
-      }
-    }
-
-    handle();
-  }, [router]);
-
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="w-full max-w-sm space-y-2 px-4 text-center">
-        {error ? (
-          <>
-            <p className="text-sm font-medium text-destructive">{error}</p>
-            <a
-              href="/auth/login"
-              className="text-xs text-muted-foreground hover:underline"
-            >
-              Back to login
-            </a>
-          </>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            Setting up your account…
-          </p>
-        )}
-      </div>
-    </div>
-  );
+  redirect("/auth/login");
 }

--- a/app/auth/callback/route.test.ts
+++ b/app/auth/callback/route.test.ts
@@ -105,63 +105,9 @@ describe("GET /auth/callback", () => {
     expect(res.headers.get("location")).toContain("error=auth_callback_error");
   });
 
-  // ── Client invite acceptance ─────────────────────────────────────────────
+  // ── Portal first-time sign-in (OTP or Google OAuth) ───────────────────────
 
-  it("accepts client invite: creates profile + portal access + redirects to portal", async () => {
-    mockSupabaseClient.auth.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
-    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
-      data: {
-        user: {
-          id: "new-client",
-          email: "c@example.com",
-          app_metadata: {},
-          user_metadata: { role: "client", tenant_id: "t1", client_id: "c1" },
-        },
-      },
-      error: null,
-    });
-    // no existing profile
-    mockSupabaseFrom.mockReturnValueOnce(makeChain({ data: null, error: null }));
-    // admin: tenant lookup
-    mockAdminFrom
-      .mockReturnValueOnce(makeChain({ data: { slug: "acme" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: null, error: null })) // profiles insert
-      .mockReturnValueOnce(makeChain({ data: null, error: null })); // portal_access insert
-    mockAdminAuthAdmin.updateUserById.mockResolvedValueOnce({ error: null });
-
-    const res = await GET(makeRequest({ code: "ok-code" }));
-    expect(res.headers.get("location")).toContain("/portal/acme");
-    expect(mockAdminAuthAdmin.updateUserById).toHaveBeenCalledWith(
-      "new-client",
-      expect.objectContaining({
-        app_metadata: expect.objectContaining({ role: "client", tenant_slug: "acme" }),
-      })
-    );
-  });
-
-  it("rejects invite when tenant not found", async () => {
-    mockSupabaseClient.auth.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
-    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
-      data: {
-        user: {
-          id: "u1",
-          app_metadata: {},
-          user_metadata: { role: "client", tenant_id: "bad-tenant", client_id: "c1" },
-        },
-      },
-      error: null,
-    });
-    mockSupabaseFrom.mockReturnValueOnce(makeChain({ data: null, error: null }));
-    mockAdminFrom.mockReturnValueOnce(makeChain({ data: null, error: null })); // tenant not found
-    mockSupabaseClient.auth.signOut.mockResolvedValueOnce({});
-
-    const res = await GET(makeRequest({ code: "ok-code" }));
-    expect(res.headers.get("location")).toContain("error=auth_callback_error");
-  });
-
-  // ── Portal Google OAuth first-time ────────────────────────────────────────
-
-  it("creates client profile on first portal OAuth when email matches a client", async () => {
+  it("creates client profile on first portal sign-in when email matches a client (no existing access row)", async () => {
     mockSupabaseClient.auth.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
     mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
       data: {
@@ -180,15 +126,50 @@ describe("GET /auth/callback", () => {
     mockAdminFrom
       .mockReturnValueOnce(makeChain({ data: { id: "t1", slug: "acme" }, error: null }))
       .mockReturnValueOnce(makeChain({ data: { id: "c1" }, error: null })) // clients match
-      .mockReturnValueOnce(makeChain({ data: null, error: null })) // profiles insert
-      .mockReturnValueOnce(makeChain({ data: null, error: null })); // portal_access insert
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))         // profiles insert
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))         // no existing access row
+      .mockReturnValueOnce(makeChain({ data: null, error: null }));        // access insert
     mockAdminAuthAdmin.updateUserById.mockResolvedValueOnce({ error: null });
 
     const res = await GET(makeRequest({ code: "ok-code", next: "/portal/acme" }));
     expect(res.headers.get("location")).toContain("/portal/acme");
   });
 
-  it("returns not_invited when OAuth email doesn't match any client", async () => {
+  it("updates existing pending access row on first OTP sign-in", async () => {
+    mockSupabaseClient.auth.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
+    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: "otp-user",
+          email: "client@example.com",
+          app_metadata: {},
+          user_metadata: {},
+        },
+      },
+      error: null,
+    });
+    // no existing profile
+    mockSupabaseFrom.mockReturnValueOnce(makeChain({ data: null, error: null }));
+
+    const updateAccessChain = makeChain({ data: null, error: null });
+
+    mockAdminFrom
+      .mockReturnValueOnce(makeChain({ data: { id: "t1", slug: "acme" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: { id: "c1" }, error: null }))          // client match
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))                  // profiles insert
+      .mockReturnValueOnce(makeChain({ data: { id: "existing-row" }, error: null })) // existing access
+      .mockReturnValueOnce(updateAccessChain);                                       // update access
+    mockAdminAuthAdmin.updateUserById.mockResolvedValueOnce({ error: null });
+
+    const res = await GET(makeRequest({ code: "ok-code", next: "/portal/acme" }));
+    expect(res.headers.get("location")).toContain("/portal/acme");
+    // Should UPDATE not INSERT when row exists
+    expect(updateAccessChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: "otp-user", accepted_at: expect.any(String) })
+    );
+  });
+
+  it("returns not_invited when email doesn't match any client", async () => {
     mockSupabaseClient.auth.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
     mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
       data: {
@@ -209,6 +190,27 @@ describe("GET /auth/callback", () => {
 
     const res = await GET(makeRequest({ code: "ok-code", next: "/portal/acme" }));
     expect(res.headers.get("location")).toContain("error=not_invited");
+  });
+
+  it("redirects to login error when portal tenant not found", async () => {
+    mockSupabaseClient.auth.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
+    mockSupabaseClient.auth.getUser.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: "u1",
+          email: "c@example.com",
+          app_metadata: {},
+          user_metadata: {},
+        },
+      },
+      error: null,
+    });
+    mockSupabaseFrom.mockReturnValueOnce(makeChain({ data: null, error: null }));
+    mockAdminFrom.mockReturnValueOnce(makeChain({ data: null, error: null })); // tenant not found
+    mockSupabaseClient.auth.signOut.mockResolvedValueOnce({});
+
+    const res = await GET(makeRequest({ code: "ok-code", next: "/portal/bad-slug" }));
+    expect(res.headers.get("location")).toContain("error=auth_callback_error");
   });
 
   // ── First-time OAuth admin sign-in ────────────────────────────────────────

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -55,51 +55,12 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${origin}${next}`);
   }
 
-  // ── Client invite acceptance ──────────────────────────────────────────────
-  if (user.user_metadata?.role === "client") {
-    const tenantId = user.user_metadata.tenant_id as string;
-    const clientId = user.user_metadata.client_id as string;
-    if (!tenantId || !clientId) {
-      await supabase.auth.signOut();
-      return NextResponse.redirect(`${origin}/auth/login?error=auth_callback_error`);
-    }
-    const admin = createAdminClient();
-    const { data: tenant } = await admin
-      .from("tenants")
-      .select("slug")
-      .eq("id", tenantId)
-      .single();
-    if (!tenant) {
-      await supabase.auth.signOut();
-      return NextResponse.redirect(`${origin}/auth/login?error=auth_callback_error`);
-    }
-    await admin.from("profiles").insert({
-      id: user.id,
-      tenant_id: tenantId,
-      role: "client",
-      full_name:
-        user.user_metadata.full_name ?? user.email?.split("@")[0] ?? "Client",
-    });
-    await admin.from("client_portal_access").insert({
-      tenant_id: tenantId,
-      client_id: clientId,
-      user_id: user.id,
-      invited_at: new Date().toISOString(),
-      accepted_at: new Date().toISOString(),
-    });
-    await admin.auth.admin.updateUserById(user.id, {
-      app_metadata: {
-        role: "client",
-        tenant_id: tenantId,
-        tenant_slug: tenant.slug,
-      },
-    });
-    return NextResponse.redirect(`${origin}/portal/${tenant.slug}`);
-  }
-
-  // ── Portal Google OAuth first-time sign-in ──────────────────────────────
-  // No profile + not an email invite + next is a portal URL.
+  // ── Portal first-time sign-in (OTP magic link OR Google OAuth) ──────────
+  // No profile + next is a portal URL.
   // Match the user's email to an existing clients record to authorize access.
+  // If the admin already granted access (pending row exists), update it.
+  // Otherwise insert a new access row (backwards-compat for Google OAuth
+  // users who weren't pre-invited).
   if (next.startsWith("/portal/")) {
     const portalSlug = next.split("/")[2];
     const admin = createAdminClient();
@@ -141,12 +102,31 @@ export async function GET(request: NextRequest) {
       role: "client",
       full_name: displayName,
     });
-    await admin.from("client_portal_access").insert({
-      tenant_id: tenant.id,
-      client_id: client.id,
-      user_id: user.id,
-      accepted_at: new Date().toISOString(),
-    });
+
+    // Update existing pending row if present (OTP invite flow),
+    // otherwise insert a new row (e.g. Google OAuth without prior invite).
+    const { data: existingAccess } = await admin
+      .from("client_portal_access")
+      .select("id")
+      .eq("client_id", client.id)
+      .eq("tenant_id", tenant.id)
+      .maybeSingle();
+
+    if (existingAccess) {
+      await admin
+        .from("client_portal_access")
+        .update({ user_id: user.id, accepted_at: new Date().toISOString() })
+        .eq("client_id", client.id)
+        .eq("tenant_id", tenant.id);
+    } else {
+      await admin.from("client_portal_access").insert({
+        tenant_id: tenant.id,
+        client_id: client.id,
+        user_id: user.id,
+        accepted_at: new Date().toISOString(),
+      });
+    }
+
     await admin.auth.admin.updateUserById(user.id, {
       app_metadata: {
         role: "client",

--- a/components/portal/PortalAccessSection.tsx
+++ b/components/portal/PortalAccessSection.tsx
@@ -1,24 +1,11 @@
 "use client";
 import { useActionState, useTransition, useState } from "react";
-import { useFormStatus } from "react-dom";
 import {
-  inviteClientToPortalAction,
   sendPortalSignInLinkAction,
   revokePortalAccessAction,
 } from "@/app/actions/portal";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { CheckCircle2, Eye } from "lucide-react";
-
-function SubmitButton() {
-  const { pending } = useFormStatus();
-  return (
-    <Button type="submit" size="sm" className="h-7 text-xs" disabled={pending}>
-      {pending ? "Sending…" : "Send invite"}
-    </Button>
-  );
-}
+import { CheckCircle2, Clock, Eye } from "lucide-react";
 
 function formatDate(d: string | null) {
   if (!d) return null;
@@ -46,9 +33,6 @@ export function PortalAccessSection({
   lastSeenAt: string | null;
   portalEmail: string | null;
 }) {
-  const boundInvite = inviteClientToPortalAction.bind(null, clientId);
-  const [inviteState, inviteFormAction] = useActionState(boundInvite, null);
-
   const boundSendLink = sendPortalSignInLinkAction.bind(null, clientId);
   const [linkState, sendLinkAction] = useActionState(boundSendLink, null);
 
@@ -71,14 +55,14 @@ export function PortalAccessSection({
         Client Portal Access
       </h2>
 
-      {hasAccess ? (
+      {/* ── Active: client has signed in at least once ── */}
+      {hasAccess && acceptedAt ? (
         <div className="space-y-3">
           <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
             <CheckCircle2 className="h-4 w-4 shrink-0" />
             <span>Portal access active</span>
           </div>
 
-          {/* Status details */}
           <dl className="space-y-1">
             {portalEmail && (
               <div className="flex gap-4">
@@ -92,12 +76,10 @@ export function PortalAccessSection({
                 <dd className="text-foreground text-xs">{formatDate(invitedAt)}</dd>
               </div>
             )}
-            {acceptedAt && (
-              <div className="flex gap-4">
-                <dt className="w-28 shrink-0 text-muted-foreground text-xs">First login</dt>
-                <dd className="text-foreground text-xs">{formatDate(acceptedAt)}</dd>
-              </div>
-            )}
+            <div className="flex gap-4">
+              <dt className="w-28 shrink-0 text-muted-foreground text-xs">First login</dt>
+              <dd className="text-foreground text-xs">{formatDate(acceptedAt)}</dd>
+            </div>
             <div className="flex gap-4">
               <dt className="w-28 shrink-0 text-muted-foreground text-xs">Last seen</dt>
               <dd className="text-foreground text-xs">
@@ -107,7 +89,6 @@ export function PortalAccessSection({
           </dl>
 
           <div className="flex items-center gap-2 flex-wrap">
-            {/* Impersonate */}
             <Button
               size="sm"
               variant="outline"
@@ -119,10 +100,9 @@ export function PortalAccessSection({
               Impersonate
             </Button>
 
-            {/* Send sign-in link */}
             {linkState?.success ? (
               <span className="text-xs text-emerald-600 dark:text-emerald-400">
-                Sign-in link sent.
+                Access link sent.
               </span>
             ) : (
               <form action={sendLinkAction}>
@@ -133,12 +113,82 @@ export function PortalAccessSection({
                   className="h-7 text-xs"
                   disabled={isPending}
                 >
-                  Send sign-in link
+                  Resend access link
                 </Button>
               </form>
             )}
 
-            {/* Revoke access */}
+            {confirmRevoke ? (
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">Revoke access?</span>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  className="h-7 text-xs"
+                  disabled={isPending}
+                  onClick={handleRevoke}
+                >
+                  {isPending ? "Revoking…" : "Yes, revoke"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-xs"
+                  disabled={isPending}
+                  onClick={() => setConfirmRevoke(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs text-destructive hover:text-destructive"
+                onClick={() => setConfirmRevoke(true)}
+              >
+                Revoke access
+              </Button>
+            )}
+          </div>
+
+          {linkState?.error && (
+            <p className="text-xs text-destructive">{linkState.error}</p>
+          )}
+        </div>
+      ) : hasAccess && !acceptedAt ? (
+        /* ── Pending: invite sent, client hasn't logged in yet ── */
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400">
+            <Clock className="h-4 w-4 shrink-0" />
+            <span>Awaiting first login</span>
+          </div>
+
+          {invitedAt && (
+            <p className="text-xs text-muted-foreground">
+              Invite sent {formatDate(invitedAt)} — client has not logged in yet.
+            </p>
+          )}
+
+          <div className="flex items-center gap-2 flex-wrap">
+            {linkState?.success ? (
+              <span className="text-xs text-emerald-600 dark:text-emerald-400">
+                Access link sent.
+              </span>
+            ) : (
+              <form action={sendLinkAction}>
+                <Button
+                  type="submit"
+                  size="sm"
+                  variant="outline"
+                  className="h-7 text-xs"
+                  disabled={isPending}
+                >
+                  Resend access link
+                </Button>
+              </form>
+            )}
+
             {confirmRevoke ? (
               <div className="flex items-center gap-1.5">
                 <span className="text-xs text-muted-foreground">Revoke access?</span>
@@ -178,39 +228,35 @@ export function PortalAccessSection({
           )}
         </div>
       ) : (
-        <>
-          <p className="text-sm text-muted-foreground mb-3">
-            {invitedAt
-              ? `Invite sent ${formatDate(invitedAt)} — client has not yet accepted.`
-              : "Invite this client to access their portal. They'll receive an email with a magic link to set up their account."}
+        /* ── Not invited: no portal access row ── */
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            {clientEmail
+              ? `Grant ${clientEmail} access to the client portal.`
+              : "Grant this client access to the client portal."}
           </p>
-          {inviteState?.success ? (
+
+          {linkState?.success ? (
             <p className="text-sm text-emerald-600 dark:text-emerald-400">
-              Invite sent successfully.
+              Access link sent — invite is pending client login.
             </p>
           ) : (
-            <form action={inviteFormAction} className="flex items-end gap-2 max-w-sm">
-              <div className="flex-1 space-y-1">
-                <Label htmlFor="portal-invite-email" className="text-xs">
-                  Email address
-                </Label>
-                <Input
-                  id="portal-invite-email"
-                  name="email"
-                  type="email"
-                  defaultValue={clientEmail ?? ""}
-                  placeholder="client@example.com"
-                  className="h-7 text-xs"
-                  required
-                />
-              </div>
-              <SubmitButton />
+            <form action={sendLinkAction}>
+              <Button
+                type="submit"
+                size="sm"
+                className="h-7 text-xs"
+                disabled={isPending || !clientEmail}
+              >
+                Grant portal access
+              </Button>
             </form>
           )}
-          {inviteState?.error && (
-            <p className="mt-1.5 text-xs text-destructive">{inviteState.error}</p>
+
+          {linkState?.error && (
+            <p className="mt-1.5 text-xs text-destructive">{linkState.error}</p>
           )}
-        </>
+        </div>
       )}
     </div>
   );

--- a/components/portal/PortalLoginForm.tsx
+++ b/components/portal/PortalLoginForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,7 +11,7 @@ function errorMessage(code: string | undefined): string | null {
     case "auth_callback_error":
       return "Authentication failed. Please try again.";
     case "not_invited":
-      return "Your Google account is not linked to a portal invitation.";
+      return "This email hasn't been granted portal access. Please contact your consultant.";
     default:
       return null;
   }
@@ -49,38 +48,16 @@ export function PortalLoginForm({
   tenantSlug: string;
   initialError?: string;
 }) {
-  const router = useRouter();
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(errorMessage(initialError));
-  const [loading, setLoading] = useState(false);
   const [magicLinkLoading, setMagicLinkLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
   const [magicLinkSent, setMagicLinkSent] = useState(false);
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setError(null);
-    setLoading(true);
-    const supabase = createClient();
-    const { error: signInError } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
-    if (signInError) {
-      setError(signInError.message);
-      setLoading(false);
-      return;
-    }
-    router.push(`/portal/${tenantSlug}`);
-    router.refresh();
-  }
+  const busy = magicLinkLoading || googleLoading;
 
-  async function handleMagicLink() {
-    if (!email) {
-      setError("Enter your email above first.");
-      return;
-    }
+  async function handleMagicLink(e: React.FormEvent) {
+    e.preventDefault();
     setError(null);
     setMagicLinkLoading(true);
     const supabase = createClient();
@@ -115,13 +92,11 @@ export function PortalLoginForm({
     // On success the browser redirects — no further action needed here
   }
 
-  const busy = loading || magicLinkLoading || googleLoading;
-
   if (magicLinkSent) {
     return (
       <Alert>
         <AlertDescription>
-          Check your email for a sign-in link.
+          Check your inbox — we sent a sign-in link to <strong>{email}</strong>.
         </AlertDescription>
       </Alert>
     );
@@ -135,32 +110,8 @@ export function PortalLoginForm({
         </Alert>
       )}
 
-      {/* Google OAuth */}
-      <Button
-        type="button"
-        variant="outline"
-        className="w-full"
-        disabled={busy}
-        onClick={handleGoogleSignIn}
-      >
-        <GoogleIcon />
-        <span className="ml-2">
-          {googleLoading ? "Redirecting…" : "Continue with Google"}
-        </span>
-      </Button>
-
-      {/* Divider */}
-      <div className="relative">
-        <div className="absolute inset-0 flex items-center">
-          <span className="w-full border-t border-border" />
-        </div>
-        <div className="relative flex justify-center text-xs">
-          <span className="bg-background px-2 text-muted-foreground">or</span>
-        </div>
-      </div>
-
-      {/* Email / password */}
-      <form onSubmit={handleSubmit} className="space-y-4">
+      {/* Primary: email → magic link */}
+      <form onSubmit={handleMagicLink} className="space-y-3">
         <div className="space-y-1.5">
           <Label htmlFor="email">Email</Label>
           <Input
@@ -172,31 +123,33 @@ export function PortalLoginForm({
             onChange={(e) => setEmail(e.target.value)}
           />
         </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="password">Password</Label>
-          <Input
-            id="password"
-            type="password"
-            autoComplete="current-password"
-            required
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-        </div>
         <Button type="submit" className="w-full" disabled={busy}>
-          {loading ? "Signing in…" : "Sign in"}
+          {magicLinkLoading ? "Sending…" : "Email me a sign-in link"}
         </Button>
       </form>
 
-      {/* Magic link */}
+      {/* Divider */}
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t border-border" />
+        </div>
+        <div className="relative flex justify-center text-xs">
+          <span className="bg-background px-2 text-muted-foreground">or</span>
+        </div>
+      </div>
+
+      {/* Secondary: Google OAuth */}
       <Button
         type="button"
-        variant="ghost"
-        className="w-full text-muted-foreground"
+        variant="outline"
+        className="w-full"
         disabled={busy}
-        onClick={handleMagicLink}
+        onClick={handleGoogleSignIn}
       >
-        {magicLinkLoading ? "Sending…" : "Email me a sign-in link"}
+        <GoogleIcon />
+        <span className="ml-2">
+          {googleLoading ? "Redirecting…" : "Continue with Google"}
+        </span>
       </Button>
     </div>
   );

--- a/lib/supabase/__mocks__/index.ts
+++ b/lib/supabase/__mocks__/index.ts
@@ -66,6 +66,7 @@ export const mockAdminAuthAdmin = {
   updateUserById: vi.fn(),
   deleteUser: vi.fn(),
   inviteUserByEmail: vi.fn(),
+  generateLink: vi.fn(),
 };
 
 export const mockAdminClient = {
@@ -90,5 +91,6 @@ export function resetSupabaseMocks() {
   mockAdminAuthAdmin.updateUserById.mockReset();
   mockAdminAuthAdmin.deleteUser.mockReset();
   mockAdminAuthAdmin.inviteUserByEmail.mockReset();
+  mockAdminAuthAdmin.generateLink.mockReset();
   (mockAdminClient.rpc as ReturnType<typeof vi.fn>).mockReset();
 }

--- a/supabase/migrations/20260303000010_portal_access_nullable_user.sql
+++ b/supabase/migrations/20260303000010_portal_access_nullable_user.sql
@@ -1,0 +1,15 @@
+-- Allow portal_access rows to be created before a client has signed up.
+-- The admin grants access (invited_at set, user_id null), and user_id + accepted_at
+-- are filled in when the client first signs in via /auth/callback.
+--
+-- Also replace the three-column unique constraint with a two-column one:
+-- a client can only have one portal-access record per tenant.
+
+ALTER TABLE client_portal_access
+  ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE client_portal_access
+  DROP CONSTRAINT client_portal_access_tenant_id_client_id_user_id_key;
+
+ALTER TABLE client_portal_access
+  ADD CONSTRAINT client_portal_access_tenant_id_client_id_key UNIQUE (tenant_id, client_id);


### PR DESCRIPTION
Closes #59

## Summary

- **`sendPortalSignInLinkAction`** now handles both first-invite and resend. It calls `admin.auth.admin.generateLink` to get the magic link without triggering Supabase's default email, then sends a branded invite via Resend. On first grant it inserts a pending `client_portal_access` row (`invited_at` set, `user_id`/`accepted_at` null); subsequent calls skip row creation.
- **`inviteClientToPortalAction`** and **`finalizeInviteAction`** removed. `auth/accept-invite/page.tsx` now redirects to `/auth/login` (dead code).
- **`auth/callback/route.ts`**: removed the old `user_metadata.role="client"` invite-acceptance branch. OTP first-visits fall through to the portal-URL branch (same path as Google OAuth). That branch now upserts `accepted_at` on existing pending rows instead of always inserting (so the unique constraint added by migration 010 is respected).
- **`PortalLoginForm`**: password form removed. Email → "Email me a sign-in link" is the primary action. Google OAuth is a smaller secondary option below a divider.
- **`PortalAccessSection`**: email `<Input>` removed. Three states — _not invited_ (single "Grant portal access" button), _pending_ (Clock icon, "Resend access link", Revoke), _active_ (existing management UI).
- **Migration 010**: `client_portal_access.user_id` made nullable; 3-column unique constraint replaced with `UNIQUE (tenant_id, client_id)` so pre-signup rows can be created.
- New **`app/api/email/portal-invite/route.ts`** (standalone, tested independently).
- `lib/supabase/__mocks__` extended with `generateLink`.

## Test plan

- [ ] `npm run test:unit` → 206 pass
- [ ] `npm run build` → clean
- [ ] Admin client detail page: "Grant portal access" button (no email input) appears when no access row
- [ ] Clicking it creates a pending row; section switches to "Awaiting first login" state
- [ ] "Resend access link" sends a new magic link email
- [ ] Client clicks magic link → `/auth/callback` → profile + accepted_at set → lands on portal
- [ ] Returning client (existing profile) → redirected directly to portal
- [ ] Portal login page: only email + "Email me a sign-in link" (primary) + Google OAuth (secondary, no password field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)