### PR TITLE
perf: replace window.confirm() with Dialog components

### DIFF
--- a/components/clients/ArchiveClientButton.tsx
+++ b/components/clients/ArchiveClientButton.tsx
@@ -1,8 +1,17 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
 import { archiveClientAction } from "@/app/actions/clients";
 import { Archive, ArchiveRestore } from "lucide-react";
 
@@ -13,42 +22,71 @@ interface ArchiveClientButtonProps {
 
 export function ArchiveClientButton({ clientId, isArchived }: ArchiveClientButtonProps) {
   const [pending, startTransition] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const router = useRouter();
 
-  function handleClick() {
-    const confirmed = window.confirm(
-      isArchived
-        ? "Unarchive this client? They will reappear in the active client list."
-        : "Archive this client? They will be hidden from the active client list."
-    );
-    if (!confirmed) return;
-
+  function handleConfirm() {
     startTransition(async () => {
       await archiveClientAction(clientId, !isArchived);
+      setConfirmOpen(false);
       router.refresh();
     });
   }
 
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={pending}
-      onClick={handleClick}
-      className="gap-1.5"
-    >
-      {isArchived ? (
-        <>
-          <ArchiveRestore className="h-3.5 w-3.5" />
-          {pending ? "Restoring…" : "Unarchive"}
-        </>
-      ) : (
-        <>
-          <Archive className="h-3.5 w-3.5" />
-          {pending ? "Archiving…" : "Archive"}
-        </>
-      )}
-    </Button>
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={pending}
+        onClick={() => setConfirmOpen(true)}
+        className="gap-1.5"
+      >
+        {isArchived ? (
+          <>
+            <ArchiveRestore className="h-3.5 w-3.5" />
+            {pending ? "Restoring…" : "Unarchive"}
+          </>
+        ) : (
+          <>
+            <Archive className="h-3.5 w-3.5" />
+            {pending ? "Archiving…" : "Archive"}
+          </>
+        )}
+      </Button>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              {isArchived ? "Unarchive this client?" : "Archive this client?"}
+            </DialogTitle>
+            <DialogDescription>
+              {isArchived
+                ? "They will reappear in the active client list."
+                : "They will be hidden from the active client list."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline" size="sm" disabled={pending}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={pending}
+              onClick={handleConfirm}
+            >
+              {pending
+                ? isArchived ? "Restoring…" : "Archiving…"
+                : isArchived ? "Unarchive" : "Archive"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/components/comments/CommentThread.tsx
+++ b/components/comments/CommentThread.tsx
@@ -8,6 +8,15 @@ import {
 } from "@/app/actions/comments";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
 import { Pencil, Trash2 } from "lucide-react";
 
 interface Comment {
@@ -48,12 +57,13 @@ function CommentRow({
   const [editing, setEditing] = useState(false);
   const [editBody, setEditBody] = useState(comment.body);
   const [editError, setEditError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const isOwn = comment.author_id === currentUserId;
 
-  function handleDelete() {
-    if (!confirm("Delete this comment?")) return;
+  function handleDeleteConfirm() {
     startTransition(async () => {
       await deleteCommentAction(comment.id, taskId);
+      setDeleteOpen(false);
     });
   }
 
@@ -140,7 +150,7 @@ function CommentRow({
             variant="ghost"
             size="sm"
             className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive"
-            onClick={handleDelete}
+            onClick={() => setDeleteOpen(true)}
             disabled={isPending}
             aria-label="Delete comment"
           >
@@ -148,6 +158,32 @@ function CommentRow({
           </Button>
         </div>
       )}
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete this comment?</DialogTitle>
+            <DialogDescription>
+              This will permanently remove the comment. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline" size="sm" disabled={isPending}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={isPending}
+              onClick={handleDeleteConfirm}
+            >
+              {isPending ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/components/tasks/AttachmentsList.tsx
+++ b/components/tasks/AttachmentsList.tsx
@@ -6,7 +6,11 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogHeader,
   DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
 } from "@/components/ui/dialog";
 import {
   Paperclip,
@@ -87,6 +91,7 @@ export function AttachmentsList({ taskId, tenantId, attachments }: AttachmentsLi
   const [isPending, startTransition] = useTransition();
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
   const [lightboxName, setLightboxName] = useState<string>("");
+  const [deleteId, setDeleteId] = useState<string | null>(null);
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -135,10 +140,11 @@ export function AttachmentsList({ taskId, tenantId, attachments }: AttachmentsLi
     }
   }
 
-  function handleDelete(attachmentId: string) {
-    if (!confirm("Delete this attachment?")) return;
+  function handleDeleteConfirm() {
+    if (!deleteId) return;
     startTransition(async () => {
-      await deleteAttachmentAction(attachmentId, taskId);
+      await deleteAttachmentAction(deleteId, taskId);
+      setDeleteId(null);
     });
   }
 
@@ -235,7 +241,7 @@ export function AttachmentsList({ taskId, tenantId, attachments }: AttachmentsLi
                   <button
                     type="button"
                     className="flex h-6 w-6 items-center justify-center rounded bg-white/20 text-white hover:bg-red-500/80 transition-colors"
-                    onClick={() => handleDelete(a.id)}
+                    onClick={() => setDeleteId(a.id)}
                     disabled={isPending}
                     title="Delete"
                   >
@@ -262,6 +268,33 @@ export function AttachmentsList({ taskId, tenantId, attachments }: AttachmentsLi
           ))}
         </div>
       )}
+
+      {/* Delete confirm */}
+      <Dialog open={!!deleteId} onOpenChange={(open) => { if (!open) setDeleteId(null); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete this attachment?</DialogTitle>
+            <DialogDescription>
+              This will permanently remove the file. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline" size="sm" disabled={isPending}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={isPending}
+              onClick={handleDeleteConfirm}
+            >
+              {isPending ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Lightbox */}
       <Dialog open={!!lightboxUrl} onOpenChange={(open) => { if (!open) setLightboxUrl(null); }}>


### PR DESCRIPTION
Closes #63

## Summary
- `ArchiveClientButton` — Dialog with Archive/Unarchive confirmation, conditional copy based on `isArchived`
- `AttachmentsList` — Delete confirm Dialog; `deleteId` state tracks which attachment is pending; existing lightbox Dialog untouched
- `CommentRow` — `deleteOpen` state + Dialog; dialog renders inside the row so each row manages its own confirm state

## Test plan
- [ ] Archive/Unarchive a client — confirm dialog appears, action runs, no `window.confirm()` in DevTools
- [ ] Delete an attachment — confirm dialog appears before deletion
- [ ] Delete a comment — confirm dialog appears before deletion
- [ ] Cancel at each dialog — no action taken
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)