### PR TITLE
perf: add loading skeletons for all data-heavy routes

### DIFF
--- a/app/(admin)/clients/[clientId]/edit/loading.tsx
+++ b/app/(admin)/clients/[clientId]/edit/loading.tsx
@@ -1,0 +1,65 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center border-b border-border px-6">
+        <div className="space-y-1">
+          <div className="h-4 w-40 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-44 rounded bg-muted/50 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content skeleton — mirrors ClientForm layout */}
+      <div className="p-6">
+        <div className="space-y-8 max-w-2xl">
+
+          {/* Basic info */}
+          <div className="space-y-4">
+            <div className="h-3.5 w-32 rounded bg-muted animate-pulse" />
+            <div className="grid grid-cols-2 gap-4">
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="space-y-1.5">
+                  <div className="h-3 w-20 rounded bg-muted/60 animate-pulse" />
+                  <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Billing info */}
+          <div className="space-y-4">
+            <div className="h-3.5 w-24 rounded bg-muted animate-pulse" />
+            <div className="grid grid-cols-2 gap-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="space-y-1.5">
+                  <div className="h-3 w-24 rounded bg-muted/60 animate-pulse" />
+                  <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Notes */}
+          <div className="space-y-4">
+            <div className="h-3.5 w-12 rounded bg-muted animate-pulse" />
+            <div className="space-y-1.5">
+              <div className="h-3 w-12 rounded bg-muted/60 animate-pulse" />
+              <div className="h-24 w-full rounded-md bg-muted/40 animate-pulse" />
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-2">
+            <div className="h-9 w-20 rounded-md bg-muted/40 animate-pulse" />
+            <div className="h-9 w-28 rounded-md bg-muted/60 animate-pulse" />
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/clients/[clientId]/loading.tsx
+++ b/app/(admin)/clients/[clientId]/loading.tsx
@@ -1,0 +1,116 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-6">
+        <div className="space-y-1">
+          <div className="h-4 w-32 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-24 rounded bg-muted/50 animate-pulse" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-7 w-20 rounded bg-muted/40 animate-pulse" />
+          <div className="h-7 w-16 rounded bg-muted/60 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-6">
+        <div className="space-y-8 max-w-4xl">
+
+          {/* Contact + billing grid */}
+          <div className="grid grid-cols-2 gap-8">
+            {[1, 2].map((col) => (
+              <div key={col} className="space-y-3">
+                <div className="h-2.5 w-16 rounded bg-muted/60 animate-pulse" />
+                <div className="h-px bg-border" />
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="flex gap-4 py-1">
+                    <div className="h-3 w-28 shrink-0 rounded bg-muted/50 animate-pulse" />
+                    <div className="h-3 w-32 rounded bg-muted/40 animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Quick actions */}
+          <div className="space-y-3">
+            <div className="h-2.5 w-24 rounded bg-muted/60 animate-pulse" />
+            <div className="flex gap-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-8 w-28 rounded-md bg-muted/40 animate-pulse" />
+              ))}
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Active tasks */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="h-2.5 w-24 rounded bg-muted/60 animate-pulse" />
+              <div className="h-5 w-14 rounded bg-muted/30 animate-pulse" />
+            </div>
+            <div className="h-px bg-border" />
+            <div className="divide-y divide-border rounded-md border border-border">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-3 px-4 py-3">
+                  <div className="h-3.5 flex-1 rounded bg-muted/50 animate-pulse" />
+                  <div className="h-5 w-14 rounded-full bg-muted/40 animate-pulse" />
+                  <div className="h-5 w-16 rounded-full bg-muted/40 animate-pulse" />
+                  <div className="h-3 w-20 rounded bg-muted/30 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Time summary */}
+          <div className="space-y-3">
+            <div className="h-2.5 w-24 rounded bg-muted/60 animate-pulse" />
+            <div className="h-px bg-border" />
+            <div className="grid grid-cols-4 gap-4">
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="rounded-md border border-border p-4 space-y-1.5">
+                  <div className="h-2.5 w-20 rounded bg-muted/50 animate-pulse" />
+                  <div className="h-6 w-14 rounded bg-muted animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Invoice history */}
+          <div className="space-y-3">
+            <div className="h-2.5 w-28 rounded bg-muted/60 animate-pulse" />
+            <div className="h-px bg-border" />
+            <div className="divide-y divide-border rounded-md border border-border">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-3 px-4 py-3">
+                  <div className="h-3.5 w-20 rounded bg-muted/60 animate-pulse" />
+                  <div className="h-3 flex-1 w-24 rounded bg-muted/40 animate-pulse" />
+                  <div className="h-5 w-16 rounded-full bg-muted/40 animate-pulse" />
+                  <div className="h-3.5 w-20 rounded bg-muted/50 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Portal access */}
+          <div className="space-y-3">
+            <div className="h-2.5 w-28 rounded bg-muted/60 animate-pulse" />
+            <div className="h-px bg-border" />
+            <div className="h-12 rounded-md border border-border bg-muted/20 animate-pulse" />
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/clients/new/loading.tsx
+++ b/app/(admin)/clients/new/loading.tsx
@@ -1,0 +1,65 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center border-b border-border px-6">
+        <div className="space-y-1">
+          <div className="h-4 w-24 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-48 rounded bg-muted/50 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content skeleton — mirrors ClientForm layout */}
+      <div className="p-6">
+        <div className="space-y-8 max-w-2xl">
+
+          {/* Basic info */}
+          <div className="space-y-4">
+            <div className="h-3.5 w-32 rounded bg-muted animate-pulse" />
+            <div className="grid grid-cols-2 gap-4">
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="space-y-1.5">
+                  <div className="h-3 w-20 rounded bg-muted/60 animate-pulse" />
+                  <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Billing info */}
+          <div className="space-y-4">
+            <div className="h-3.5 w-24 rounded bg-muted animate-pulse" />
+            <div className="grid grid-cols-2 gap-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="space-y-1.5">
+                  <div className="h-3 w-24 rounded bg-muted/60 animate-pulse" />
+                  <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Notes */}
+          <div className="space-y-4">
+            <div className="h-3.5 w-12 rounded bg-muted animate-pulse" />
+            <div className="space-y-1.5">
+              <div className="h-3 w-12 rounded bg-muted/60 animate-pulse" />
+              <div className="h-24 w-full rounded-md bg-muted/40 animate-pulse" />
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-2">
+            <div className="h-9 w-20 rounded-md bg-muted/40 animate-pulse" />
+            <div className="h-9 w-28 rounded-md bg-muted/60 animate-pulse" />
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/invoices/[invoiceId]/loading.tsx
+++ b/app/(admin)/invoices/[invoiceId]/loading.tsx
@@ -1,0 +1,106 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-6">
+        <div className="flex items-center gap-1.5">
+          <div className="h-3.5 w-10 rounded bg-muted/50 animate-pulse" />
+          <div className="h-3 w-3 rounded bg-muted/30 animate-pulse" />
+          <div className="h-3.5 w-20 rounded bg-muted animate-pulse" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-5 w-16 rounded-full bg-muted/50 animate-pulse" />
+          <div className="h-7 w-16 rounded bg-muted/40 animate-pulse" />
+          <div className="h-7 w-16 rounded bg-muted/40 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-6">
+        <div className="max-w-3xl space-y-8">
+
+          {/* Meta panel */}
+          <div className="grid grid-cols-4 gap-4 text-sm">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="space-y-1.5">
+                <div className="h-2.5 w-12 rounded bg-muted/50 animate-pulse" />
+                <div className="h-4 w-20 rounded bg-muted/60 animate-pulse" />
+              </div>
+            ))}
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Line items */}
+          <div className="space-y-3">
+            <div className="h-2.5 w-20 rounded bg-muted/60 animate-pulse" />
+            <div className="rounded-md border border-border overflow-hidden">
+              <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-4">
+                <div className="h-2.5 flex-1 rounded bg-muted animate-pulse" />
+                <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+                <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+                <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+              </div>
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-4 h-11 border-b border-border last:border-0 px-4"
+                >
+                  <div className="h-3 flex-1 rounded bg-muted/50 animate-pulse" />
+                  <div className="h-3 w-16 rounded bg-muted/40 animate-pulse" />
+                  <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+                  <div className="h-3 w-24 rounded bg-muted/40 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Totals */}
+          <div className="flex justify-end">
+            <div className="w-64 space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex justify-between">
+                  <div className="h-3 w-16 rounded bg-muted/50 animate-pulse" />
+                  <div className="h-3 w-20 rounded bg-muted/50 animate-pulse" />
+                </div>
+              ))}
+              <div className="h-px bg-border my-1" />
+              <div className="flex justify-between">
+                <div className="h-3.5 w-12 rounded bg-muted animate-pulse" />
+                <div className="h-3.5 w-24 rounded bg-muted animate-pulse" />
+              </div>
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Payments */}
+          <div className="space-y-3">
+            <div className="h-2.5 w-16 rounded bg-muted/60 animate-pulse" />
+            <div className="rounded-md border border-border overflow-hidden">
+              <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-4">
+                <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+                <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+                <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+                <div className="h-2.5 flex-1 rounded bg-muted animate-pulse" />
+              </div>
+              {[1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-4 h-11 border-b border-border last:border-0 px-4"
+                >
+                  <div className="h-3 w-20 rounded bg-muted/50 animate-pulse" />
+                  <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+                  <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+                  <div className="h-3 flex-1 rounded bg-muted/40 animate-pulse" />
+                </div>
+              ))}
+            </div>
+            <div className="h-9 w-36 rounded-md bg-muted/40 animate-pulse" />
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/invoices/new/loading.tsx
+++ b/app/(admin)/invoices/new/loading.tsx
@@ -1,0 +1,98 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center border-b border-border px-6">
+        <div className="space-y-1">
+          <div className="h-4 w-24 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-48 rounded bg-muted/50 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content skeleton — mirrors InvoiceBuilderClient layout */}
+      <div className="p-6">
+        <div className="space-y-6 max-w-3xl">
+
+          {/* Header row: client selector + invoice number */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <div className="h-3 w-12 rounded bg-muted/60 animate-pulse" />
+              <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+            </div>
+            <div className="space-y-1.5">
+              <div className="h-3 w-28 rounded bg-muted/60 animate-pulse" />
+              <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+            </div>
+          </div>
+
+          {/* Dates row */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <div className="h-3 w-20 rounded bg-muted/60 animate-pulse" />
+              <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+            </div>
+            <div className="space-y-1.5">
+              <div className="h-3 w-16 rounded bg-muted/60 animate-pulse" />
+              <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Line items table */}
+          <div className="space-y-2">
+            <div className="flex items-center gap-4 h-8 rounded-t-md bg-muted/30 px-4">
+              <div className="h-2.5 flex-1 rounded bg-muted/60 animate-pulse" />
+              <div className="h-2.5 w-16 rounded bg-muted/60 animate-pulse" />
+              <div className="h-2.5 w-20 rounded bg-muted/60 animate-pulse" />
+              <div className="h-2.5 w-24 rounded bg-muted/60 animate-pulse" />
+              <div className="w-8" />
+            </div>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-4 px-4 py-2">
+                <div className="h-8 flex-1 rounded-md bg-muted/40 animate-pulse" />
+                <div className="h-8 w-16 rounded-md bg-muted/40 animate-pulse" />
+                <div className="h-8 w-20 rounded-md bg-muted/40 animate-pulse" />
+                <div className="h-8 w-24 rounded-md bg-muted/30 animate-pulse" />
+                <div className="h-6 w-6 rounded bg-muted/30 animate-pulse" />
+              </div>
+            ))}
+            <div className="px-4">
+              <div className="h-8 w-28 rounded-md bg-muted/30 animate-pulse" />
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Totals + memo */}
+          <div className="flex justify-between gap-8">
+            <div className="flex-1 space-y-1.5">
+              <div className="h-3 w-12 rounded bg-muted/60 animate-pulse" />
+              <div className="h-20 w-full rounded-md bg-muted/40 animate-pulse" />
+            </div>
+            <div className="w-64 space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex justify-between">
+                  <div className="h-3 w-16 rounded bg-muted/50 animate-pulse" />
+                  <div className="h-3 w-20 rounded bg-muted/50 animate-pulse" />
+                </div>
+              ))}
+              <div className="h-px bg-border" />
+              <div className="flex justify-between">
+                <div className="h-4 w-12 rounded bg-muted animate-pulse" />
+                <div className="h-4 w-24 rounded bg-muted animate-pulse" />
+              </div>
+            </div>
+          </div>
+
+          {/* Save button */}
+          <div className="flex justify-end gap-2">
+            <div className="h-9 w-24 rounded-md bg-muted/40 animate-pulse" />
+            <div className="h-9 w-28 rounded-md bg-muted/60 animate-pulse" />
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/reports/ReportsFilterForm.tsx
+++ b/app/(admin)/reports/ReportsFilterForm.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+interface ReportsFilterFormProps {
+  defaultStart: string;
+  defaultEnd: string;
+}
+
+export function ReportsFilterForm({ defaultStart, defaultEnd }: ReportsFilterFormProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const start = (form.elements.namedItem("start") as HTMLInputElement).value;
+    const end = (form.elements.namedItem("end") as HTMLInputElement).value;
+    startTransition(() => {
+      router.push(`?start=${start}&end=${end}`);
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-end gap-3">
+      <div className="space-y-1">
+        <label htmlFor="start" className="text-xs font-medium text-muted-foreground">
+          From
+        </label>
+        <input
+          id="start"
+          name="start"
+          type="date"
+          defaultValue={defaultStart}
+          className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="end" className="text-xs font-medium text-muted-foreground">
+          To
+        </label>
+        <input
+          id="end"
+          name="end"
+          type="date"
+          defaultValue={defaultEnd}
+          className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={isPending}
+        className="h-9 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {isPending ? "Loading…" : "Apply"}
+      </button>
+    </form>
+  );
+}

--- a/app/(admin)/reports/loading.tsx
+++ b/app/(admin)/reports/loading.tsx
@@ -1,0 +1,116 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-6">
+        <div className="space-y-1">
+          <div className="h-4 w-20 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-48 rounded bg-muted/50 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-6 space-y-10">
+        {/* Date range filter */}
+        <div className="flex items-end gap-3">
+          <div className="space-y-1">
+            <div className="h-3 w-8 rounded bg-muted/50 animate-pulse" />
+            <div className="h-9 w-36 rounded-md bg-muted/40 animate-pulse" />
+          </div>
+          <div className="space-y-1">
+            <div className="h-3 w-4 rounded bg-muted/50 animate-pulse" />
+            <div className="h-9 w-36 rounded-md bg-muted/40 animate-pulse" />
+          </div>
+          <div className="h-9 w-16 rounded-md bg-muted/60 animate-pulse" />
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* Revenue by client */}
+        <div className="space-y-4">
+          <div className="h-4 w-36 rounded bg-muted animate-pulse" />
+          <div className="rounded-md border border-border overflow-hidden">
+            <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-4">
+              <div className="h-2.5 flex-1 rounded bg-muted animate-pulse" />
+              <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+              <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+              <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+              <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+            </div>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-4 h-10 border-b border-border last:border-0 px-4"
+              >
+                <div className="flex items-center gap-2 flex-1">
+                  <div className="h-2.5 w-2.5 rounded-full bg-muted/60 animate-pulse" />
+                  <div className="h-3 w-28 rounded bg-muted/50 animate-pulse" />
+                </div>
+                <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+                <div className="h-3 w-24 rounded bg-muted/40 animate-pulse" />
+                <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+                <div className="h-3 w-16 rounded bg-muted/40 animate-pulse" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* Revenue by month */}
+        <div className="space-y-4">
+          <div className="h-4 w-36 rounded bg-muted animate-pulse" />
+          <div className="rounded-md border border-border overflow-hidden">
+            <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-4">
+              <div className="h-2.5 flex-1 rounded bg-muted animate-pulse" />
+              <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+              <div className="h-2.5 w-20 rounded bg-muted animate-pulse" />
+              <div className="h-2.5 w-16 rounded bg-muted animate-pulse" />
+            </div>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-4 h-10 border-b border-border last:border-0 px-4"
+              >
+                <div className="h-3 flex-1 w-28 rounded bg-muted/50 animate-pulse" />
+                <div className="h-3 w-24 rounded bg-muted/40 animate-pulse" />
+                <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+                <div className="h-3 w-16 rounded bg-muted/40 animate-pulse" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* Unbilled hours */}
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <div className="h-4 w-28 rounded bg-muted animate-pulse" />
+            <div className="h-3 w-72 rounded bg-muted/50 animate-pulse" />
+          </div>
+          <div className="rounded-md border border-border overflow-hidden">
+            <div className="flex items-center gap-4 h-9 border-b border-border bg-muted/30 px-4">
+              <div className="h-2.5 flex-1 rounded bg-muted animate-pulse" />
+              <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+              <div className="h-2.5 w-28 rounded bg-muted animate-pulse" />
+            </div>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-4 h-10 border-b border-border last:border-0 px-4"
+              >
+                <div className="flex items-center gap-2 flex-1">
+                  <div className="h-2.5 w-2.5 rounded-full bg-muted/60 animate-pulse" />
+                  <div className="h-3 w-28 rounded bg-muted/50 animate-pulse" />
+                </div>
+                <div className="h-3 w-24 rounded bg-muted/40 animate-pulse" />
+                <div className="h-3 w-28 rounded bg-muted/40 animate-pulse" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/reports/page.tsx
+++ b/app/(admin)/reports/page.tsx
@@ -3,6 +3,7 @@ import { TopBar } from "@/components/layout/TopBar";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { Separator } from "@/components/ui/separator";
 import { createClient, getCachedUser } from "@/lib/supabase/server";
+import { ReportsFilterForm } from "./ReportsFilterForm";
 
 interface SearchParams {
   start?: string;
@@ -185,38 +186,7 @@ export default async function ReportsPage({
         <div className="space-y-10">
 
           {/* Date range filter */}
-          <form method="GET" className="flex items-end gap-3">
-            <div className="space-y-1">
-              <label htmlFor="start" className="text-xs font-medium text-muted-foreground">
-                From
-              </label>
-              <input
-                id="start"
-                name="start"
-                type="date"
-                defaultValue={start}
-                className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-              />
-            </div>
-            <div className="space-y-1">
-              <label htmlFor="end" className="text-xs font-medium text-muted-foreground">
-                To
-              </label>
-              <input
-                id="end"
-                name="end"
-                type="date"
-                defaultValue={end}
-                className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-              />
-            </div>
-            <button
-              type="submit"
-              className="h-9 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-            >
-              Apply
-            </button>
-          </form>
+          <ReportsFilterForm defaultStart={start} defaultEnd={end} />
 
           <Separator />
 

--- a/app/(admin)/settings/loading.tsx
+++ b/app/(admin)/settings/loading.tsx
@@ -1,0 +1,102 @@
+function FormSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="space-y-1.5">
+          <div className="h-3 w-28 rounded bg-muted/60 animate-pulse" />
+          <div className="h-9 w-full max-w-sm rounded-md bg-muted/40 animate-pulse" />
+        </div>
+      ))}
+      <div className="h-8 w-20 rounded-md bg-muted/60 animate-pulse" />
+    </div>
+  );
+}
+
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center border-b border-border px-6">
+        <div className="space-y-1">
+          <div className="h-4 w-20 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-56 rounded bg-muted/50 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-6">
+        <div className="space-y-10 max-w-3xl">
+
+          {/* Business info */}
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <div className="h-4 w-40 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-64 rounded bg-muted/50 animate-pulse" />
+            </div>
+            <FormSkeleton rows={4} />
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Branding */}
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <div className="h-4 w-20 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-52 rounded bg-muted/50 animate-pulse" />
+            </div>
+            <div className="flex items-center gap-4">
+              <div className="h-16 w-16 rounded-md bg-muted/40 animate-pulse" />
+              <div className="space-y-2">
+                <div className="h-8 w-24 rounded-md bg-muted/40 animate-pulse" />
+                <div className="h-3 w-32 rounded bg-muted/30 animate-pulse" />
+              </div>
+            </div>
+            <div className="h-8 w-20 rounded-md bg-muted/60 animate-pulse" />
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Invoice settings */}
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <div className="h-4 w-32 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-56 rounded bg-muted/50 animate-pulse" />
+            </div>
+            <FormSkeleton rows={3} />
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Email templates */}
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <div className="h-4 w-32 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-52 rounded bg-muted/50 animate-pulse" />
+            </div>
+            <div className="space-y-1.5">
+              <div className="h-3 w-28 rounded bg-muted/60 animate-pulse" />
+              <div className="h-24 w-full rounded-md bg-muted/40 animate-pulse" />
+            </div>
+            <div className="h-8 w-20 rounded-md bg-muted/60 animate-pulse" />
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {/* Portal URL */}
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <div className="h-4 w-24 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-52 rounded bg-muted/50 animate-pulse" />
+            </div>
+            <div className="space-y-1.5">
+              <div className="h-3 w-20 rounded bg-muted/60 animate-pulse" />
+              <div className="h-9 w-full max-w-sm rounded-md bg-muted/40 animate-pulse" />
+            </div>
+            <div className="h-8 w-20 rounded-md bg-muted/60 animate-pulse" />
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/tasks/new/loading.tsx
+++ b/app/(admin)/tasks/new/loading.tsx
@@ -1,0 +1,50 @@
+export default function Loading() {
+  return (
+    <>
+      {/* TopBar skeleton */}
+      <div className="flex h-14 items-center border-b border-border px-6">
+        <div className="space-y-1">
+          <div className="h-4 w-20 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-44 rounded bg-muted/50 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content skeleton — mirrors NewTaskForm layout */}
+      <div className="p-6">
+        <div className="max-w-xl space-y-5">
+
+          {/* Title */}
+          <div className="space-y-1.5">
+            <div className="h-3 w-10 rounded bg-muted/60 animate-pulse" />
+            <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+          </div>
+
+          {/* Client */}
+          <div className="space-y-1.5">
+            <div className="h-3 w-12 rounded bg-muted/60 animate-pulse" />
+            <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+          </div>
+
+          {/* Priority */}
+          <div className="space-y-1.5">
+            <div className="h-3 w-14 rounded bg-muted/60 animate-pulse" />
+            <div className="h-9 w-full rounded-md bg-muted/40 animate-pulse" />
+          </div>
+
+          {/* Due date */}
+          <div className="space-y-1.5">
+            <div className="h-3 w-16 rounded bg-muted/60 animate-pulse" />
+            <div className="h-9 w-48 rounded-md bg-muted/40 animate-pulse" />
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-2 pt-1">
+            <div className="h-8 w-16 rounded-md bg-muted/40 animate-pulse" />
+            <div className="h-8 w-24 rounded-md bg-muted/60 animate-pulse" />
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/portal/[tenantSlug]/(protected)/loading.tsx
+++ b/app/portal/[tenantSlug]/(protected)/loading.tsx
@@ -1,0 +1,27 @@
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      {/* Heading */}
+      <div className="space-y-1.5">
+        <div className="h-5 w-24 rounded bg-muted animate-pulse" />
+        <div className="h-3.5 w-64 rounded bg-muted/50 animate-pulse" />
+      </div>
+
+      {/* Task list */}
+      <div className="divide-y divide-border rounded-md border border-border">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 px-4 py-3">
+            <div className="flex-1 space-y-1">
+              <div className="h-3.5 w-48 rounded bg-muted/60 animate-pulse" />
+              <div className="h-3 w-24 rounded bg-muted/40 animate-pulse" />
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <div className="h-5 w-14 rounded-full bg-muted/40 animate-pulse" />
+              <div className="h-5 w-16 rounded-full bg-muted/40 animate-pulse" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/portal/[tenantSlug]/(protected)/tasks/[taskId]/loading.tsx
+++ b/app/portal/[tenantSlug]/(protected)/tasks/[taskId]/loading.tsx
@@ -1,0 +1,70 @@
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <div className="h-3 w-20 rounded bg-muted/40 animate-pulse" />
+
+      {/* Title + badges */}
+      <div className="space-y-2">
+        <div className="h-5 w-64 rounded bg-muted animate-pulse" />
+        <div className="flex items-center gap-2">
+          <div className="h-5 w-16 rounded-full bg-muted/50 animate-pulse" />
+          <div className="h-5 w-14 rounded-full bg-muted/40 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Meta panel */}
+      <div className="grid grid-cols-2 gap-4 rounded-md border border-border bg-muted/20 px-5 py-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex gap-3">
+            <div className="h-3 w-20 shrink-0 rounded bg-muted/50 animate-pulse" />
+            <div className="h-3 w-24 rounded bg-muted/40 animate-pulse" />
+          </div>
+        ))}
+      </div>
+
+      <div className="h-px bg-border" />
+
+      {/* Description */}
+      <div className="space-y-2">
+        <div className="h-2.5 w-20 rounded bg-muted/60 animate-pulse" />
+        <div className="h-16 rounded-md bg-muted/30 animate-pulse" />
+      </div>
+
+      <div className="h-px bg-border" />
+
+      {/* Comments */}
+      <div className="space-y-3">
+        <div className="h-2.5 w-20 rounded bg-muted/60 animate-pulse" />
+        <div className="divide-y divide-border rounded-md border border-border">
+          {[1, 2].map((i) => (
+            <div key={i} className="flex gap-3 px-3 py-3">
+              <div className="h-7 w-7 shrink-0 rounded-full bg-muted animate-pulse" />
+              <div className="flex-1 space-y-1.5">
+                <div className="h-2.5 w-32 rounded bg-muted animate-pulse" />
+                <div className="h-3.5 w-full rounded bg-muted/60 animate-pulse" />
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="h-20 rounded-md border border-border bg-muted/10 animate-pulse" />
+      </div>
+
+      <div className="h-px bg-border" />
+
+      {/* Activity log */}
+      <div className="space-y-3">
+        <div className="h-2.5 w-16 rounded bg-muted/60 animate-pulse" />
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex gap-2 items-start">
+            <div className="h-5 w-5 rounded-full bg-muted/40 animate-pulse shrink-0 mt-0.5" />
+            <div className="space-y-1 flex-1">
+              <div className="h-3 w-48 rounded bg-muted/40 animate-pulse" />
+              <div className="h-2.5 w-24 rounded bg-muted/30 animate-pulse" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #64

## Summary
- Adds `loading.tsx` for all 10 routes listed in the issue — each structurally mirrors the real page using `animate-pulse` skeleton blocks
- Extracts the Reports filter form into `ReportsFilterForm.tsx` (client component) with `useTransition` so the Apply button shows "Loading…" and is disabled while navigation is pending

## Routes covered
| Route | File |
|---|---|
| `/reports` | `app/(admin)/reports/loading.tsx` |
| `/settings` | `app/(admin)/settings/loading.tsx` |
| `/invoices/[invoiceId]` | `app/(admin)/invoices/[invoiceId]/loading.tsx` |
| `/invoices/new` | `app/(admin)/invoices/new/loading.tsx` |
| `/clients/[clientId]` | `app/(admin)/clients/[clientId]/loading.tsx` |
| `/clients/new` | `app/(admin)/clients/new/loading.tsx` |
| `/clients/[clientId]/edit` | `app/(admin)/clients/[clientId]/edit/loading.tsx` |
| `/tasks/new` | `app/(admin)/tasks/new/loading.tsx` |
| `/portal/[tenantSlug]/(protected)` | `app/portal/[tenantSlug]/(protected)/loading.tsx` |
| `/portal/[tenantSlug]/(protected)/tasks/[taskId]` | `app/portal/[tenantSlug]/(protected)/tasks/[taskId]/loading.tsx` |

## Test plan
- [ ] `npm run build` passes
- [ ] Navigate to each route on a slow connection (throttle in DevTools) — skeleton appears instantly instead of blank page
- [ ] Reports page: click Apply — button shows "Loading…" and is disabled until the new data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)