### PR TITLE
perf: overhaul time calendar UX (#72)

### DIFF
--- a/app/(admin)/time/loading.tsx
+++ b/app/(admin)/time/loading.tsx
@@ -3,16 +3,56 @@ export default function Loading() {
     <>
       {/* TopBar skeleton */}
       <div className="flex h-14 items-center justify-between border-b border-border px-6 pl-14 md:pl-6">
-        <div className="h-4 w-28 rounded bg-muted animate-pulse" />
+        <div className="h-4 w-16 rounded bg-muted animate-pulse" />
         <div className="flex gap-2">
           <div className="h-7 w-20 rounded bg-muted/50 animate-pulse" />
           <div className="h-7 w-20 rounded bg-muted/50 animate-pulse" />
         </div>
       </div>
 
-      {/* Calendar placeholder */}
-      <div className="p-6">
-        <div className="rounded-md border border-border animate-pulse bg-muted/20" style={{ minHeight: 540 }} />
+      {/* Calendar skeleton */}
+      <div className="p-6 animate-pulse space-y-3">
+        {/* Log time button + toolbar row */}
+        <div className="flex items-center justify-between mb-1">
+          <div className="flex gap-1.5">
+            <div className="h-7 w-7 rounded bg-muted/60" />
+            <div className="h-7 w-7 rounded bg-muted/60" />
+            <div className="h-7 w-16 rounded bg-muted/60" />
+          </div>
+          <div className="h-5 w-32 rounded bg-muted/60" />
+          <div className="flex gap-1.5">
+            <div className="h-7 w-14 rounded bg-muted/60" />
+            <div className="h-7 w-14 rounded bg-muted/60" />
+            <div className="h-7 w-14 rounded bg-muted/60" />
+          </div>
+        </div>
+
+        {/* Calendar grid */}
+        <div className="rounded-md border border-border overflow-hidden">
+          {/* Day headers */}
+          <div className="grid grid-cols-7 border-b border-border bg-muted/30">
+            {Array.from({ length: 7 }).map((_, i) => (
+              <div key={i} className="px-2 py-1.5 border-r border-border last:border-r-0">
+                <div className="h-3 w-8 rounded bg-muted/60 mx-auto" />
+              </div>
+            ))}
+          </div>
+
+          {/* Day cells — 5 rows */}
+          {Array.from({ length: 5 }).map((_, r) => (
+            <div key={r} className="grid grid-cols-7 border-b border-border last:border-b-0">
+              {Array.from({ length: 7 }).map((_, c) => (
+                <div key={c} className="h-24 px-2 pt-1.5 border-r border-border last:border-r-0">
+                  <div className="h-3 w-4 rounded bg-muted/40 mb-1.5" />
+                  {r === 0 && c === 2 && <div className="h-4 rounded bg-muted/60 mb-1" />}
+                  {r === 1 && c === 4 && <div className="h-4 rounded bg-muted/60 mb-1" />}
+                  {r === 2 && c === 1 && <div className="h-4 rounded bg-muted/60 mb-1" />}
+                  {r === 2 && c === 5 && <div className="h-4 rounded bg-muted/60" />}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
     </>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -79,6 +79,132 @@
   }
 }
 
+/* ── FullCalendar overrides ──────────────────────────── */
+
+/* Map FullCalendar color tokens to our design-system CSS variables.
+   Since our vars already change under .dark { }, dark mode is automatic. */
+.fc {
+  --fc-border-color: hsl(var(--border));
+  --fc-button-bg-color: hsl(var(--muted));
+  --fc-button-border-color: hsl(var(--border));
+  --fc-button-text-color: hsl(var(--foreground));
+  --fc-button-hover-bg-color: hsl(var(--accent));
+  --fc-button-hover-border-color: hsl(var(--border));
+  --fc-button-active-bg-color: hsl(var(--primary));
+  --fc-button-active-border-color: hsl(var(--primary));
+  --fc-button-active-text-color: hsl(var(--primary-foreground));
+  --fc-today-bg-color: hsl(var(--primary) / 0.06);
+  --fc-page-bg-color: hsl(var(--background));
+  --fc-neutral-bg-color: hsl(var(--muted));
+  --fc-neutral-text-color: hsl(var(--muted-foreground));
+  --fc-list-event-hover-bg-color: hsl(var(--accent));
+  --fc-event-bg-color: hsl(var(--primary));
+  --fc-event-border-color: hsl(var(--primary));
+  --fc-event-text-color: hsl(var(--primary-foreground));
+  --fc-highlight-color: hsl(var(--primary) / 0.1);
+  font-family: var(--font-geist-sans, system-ui, -apple-system, sans-serif);
+  font-size: 0.875rem;
+}
+
+/* Buttons: match shadcn button sizing and border-radius */
+.fc .fc-button {
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: var(--radius);
+  box-shadow: none;
+  text-transform: capitalize;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.fc .fc-button:focus {
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.4);
+  outline: none;
+}
+
+.fc .fc-button-primary:not(:disabled).fc-button-active,
+.fc .fc-button-primary:not(:disabled):active {
+  background-color: hsl(var(--primary));
+  border-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+
+/* Toolbar */
+.fc .fc-toolbar.fc-header-toolbar {
+  margin-bottom: 0.75rem;
+}
+
+.fc .fc-toolbar-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+/* Column headers */
+.fc .fc-col-header-cell-cushion {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  text-decoration: none;
+}
+
+/* Day numbers */
+.fc .fc-daygrid-day-number {
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+  text-decoration: none;
+}
+
+.fc .fc-day-today .fc-daygrid-day-number {
+  color: hsl(var(--primary));
+  font-weight: 600;
+}
+
+/* Events */
+.fc .fc-event {
+  cursor: pointer;
+  font-size: 0.7rem;
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.fc .fc-event-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Per-day hour total (rendered via dayCellContent) */
+.fc .fc-day-hours {
+  font-size: 0.65rem;
+  font-variant-numeric: tabular-nums;
+  color: hsl(var(--muted-foreground));
+  padding-right: 0.25rem;
+}
+
+/* List view */
+.fc .fc-list-event:hover td {
+  background-color: hsl(var(--accent));
+  cursor: pointer;
+}
+
+.fc .fc-list-day-cushion {
+  background-color: hsl(var(--muted) / 0.5);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.fc .fc-list-event-title a {
+  color: hsl(var(--foreground));
+  text-decoration: none;
+}
+
+.fc .fc-list-empty {
+  background-color: hsl(var(--background));
+  color: hsl(var(--muted-foreground));
+  font-size: 0.875rem;
+}
+
 /* ── Milkdown Crepe editor overrides ─────────────────── */
 
 /* Map Crepe color tokens to our design-system CSS variables.

--- a/components/time/TimeCalendar.tsx
+++ b/components/time/TimeCalendar.tsx
@@ -3,12 +3,14 @@
 import { useCallback, useRef, useState } from "react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
-import timeGridPlugin from "@fullcalendar/timegrid";
+import listPlugin from "@fullcalendar/list";
 import interactionPlugin from "@fullcalendar/interaction";
 import type { DateClickArg } from "@fullcalendar/interaction";
-import type { EventClickArg, EventSourceFuncArg, EventDropArg } from "@fullcalendar/core";
+import type { EventApi, EventClickArg, EventSourceFuncArg, EventDropArg } from "@fullcalendar/core";
 import { updateTimeEntryDateAction } from "@/app/actions/time";
 import { TimeEntryModal, TimeEntryData } from "@/components/time/TimeEntryModal";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 interface Client {
@@ -36,6 +38,7 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [prefillDate, setPrefillDate] = useState<string | undefined>();
   const [editEntry, setEditEntry] = useState<TimeEntryData | undefined>();
+  const [dayHours, setDayHours] = useState<Record<string, number>>({});
 
   const fetchEvents = useCallback(
     async (info: EventSourceFuncArg, successCallback: (events: object[]) => void, failureCallback: (error: Error) => void) => {
@@ -53,10 +56,25 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
     []
   );
 
-  function handleDateClick(arg: DateClickArg) {
+  function handleEventsSet(events: EventApi[]) {
+    const totals: Record<string, number> = {};
+    events.forEach((ev) => {
+      const date = ev.start?.toISOString().split("T")[0];
+      if (date) {
+        totals[date] = (totals[date] ?? 0) + ((ev.extendedProps.durationHours as number) ?? 0);
+      }
+    });
+    setDayHours(totals);
+  }
+
+  function openCreate(date?: string) {
     setEditEntry(undefined);
-    setPrefillDate(arg.dateStr);
+    setPrefillDate(date ?? new Date().toISOString().split("T")[0]);
     setModalOpen(true);
+  }
+
+  function handleDateClick(arg: DateClickArg) {
+    openCreate(arg.dateStr);
   }
 
   function handleEventClick(arg: EventClickArg) {
@@ -85,33 +103,51 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
 
   function handleSuccess() {
     router.refresh();
-    // Refetch calendar events
-    const api = calendarRef.current?.getApi();
-    api?.refetchEvents();
+    calendarRef.current?.getApi().refetchEvents();
   }
 
   return (
     <>
-      <div className="fc-wrapper [&_.fc-toolbar-title]:text-base [&_.fc-toolbar-title]:font-semibold [&_.fc-button]:text-xs [&_.fc-button]:capitalize [&_.fc-button-primary]:bg-primary [&_.fc-button-primary]:border-primary [&_.fc-button-primary:hover]:opacity-90 [&_.fc-button-primary:not(.fc-button-active)]:bg-muted [&_.fc-button-primary:not(.fc-button-active)]:text-foreground [&_.fc-button-primary:not(.fc-button-active)]:border-border [&_.fc-button-primary:not(.fc-button-active):hover]:bg-accent [&_.fc-daygrid-day-number]:text-xs [&_.fc-col-header-cell-cushion]:text-xs [&_.fc-col-header-cell-cushion]:font-medium [&_.fc-event]:cursor-pointer [&_.fc-event-title]:truncate">
-        <FullCalendar
-          ref={calendarRef}
-          plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
-          initialView="dayGridWeek"
-          headerToolbar={{
-            left: "prev,next today",
-            center: "title",
-            right: "dayGridMonth,dayGridWeek,timeGridWeek",
-          }}
-          events={fetchEvents}
-          editable={true}
-          eventDrop={handleEventDrop}
-          dateClick={handleDateClick}
-          eventClick={handleEventClick}
-          height="auto"
-          dayMaxEvents={4}
-          eventTimeFormat={{ hour: "numeric", minute: "2-digit" }}
-        />
+      <div className="mb-3 flex justify-end">
+        <Button size="sm" className="h-7 gap-1 text-xs" onClick={() => openCreate()}>
+          <Plus className="h-3.5 w-3.5" />
+          Log time
+        </Button>
       </div>
+
+      <FullCalendar
+        ref={calendarRef}
+        plugins={[dayGridPlugin, listPlugin, interactionPlugin]}
+        initialView="dayGridWeek"
+        headerToolbar={{
+          left: "prev,next today",
+          center: "title",
+          right: "dayGridMonth,dayGridWeek,listWeek",
+        }}
+        views={{
+          listWeek: { buttonText: "Agenda" },
+        }}
+        events={fetchEvents}
+        eventsSet={handleEventsSet}
+        editable={true}
+        eventDrop={handleEventDrop}
+        dateClick={handleDateClick}
+        eventClick={handleEventClick}
+        height="auto"
+        dayMaxEvents={4}
+        dayCellContent={(arg) => {
+          const dateStr = arg.date.toISOString().split("T")[0];
+          const hours = dayHours[dateStr];
+          return (
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", width: "100%" }}>
+              <span className="fc-daygrid-day-number">{arg.dayNumberText}</span>
+              {hours != null && hours > 0 && (
+                <span className="fc-day-hours">{hours % 1 === 0 ? hours : hours.toFixed(1)}h</span>
+              )}
+            </div>
+          );
+        }}
+      />
 
       <TimeEntryModal
         open={modalOpen}

--- a/components/time/TimeCalendarWrapper.tsx
+++ b/components/time/TimeCalendarWrapper.tsx
@@ -2,9 +2,55 @@
 
 import dynamic from "next/dynamic";
 
+function CalendarSkeleton() {
+  return (
+    <div className="animate-pulse space-y-3">
+      {/* Toolbar row */}
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1.5">
+          <div className="h-7 w-7 rounded bg-muted/60" />
+          <div className="h-7 w-7 rounded bg-muted/60" />
+          <div className="h-7 w-16 rounded bg-muted/60" />
+        </div>
+        <div className="h-5 w-32 rounded bg-muted/60" />
+        <div className="flex gap-1.5">
+          <div className="h-7 w-14 rounded bg-muted/60" />
+          <div className="h-7 w-14 rounded bg-muted/60" />
+          <div className="h-7 w-14 rounded bg-muted/60" />
+        </div>
+      </div>
+      {/* Calendar grid */}
+      <div className="rounded-md border border-border overflow-hidden">
+        {/* Day headers */}
+        <div className="grid grid-cols-7 border-b border-border bg-muted/30">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div key={i} className="px-2 py-1.5 border-r border-border last:border-r-0">
+              <div className="h-3 w-8 rounded bg-muted/60 mx-auto" />
+            </div>
+          ))}
+        </div>
+        {/* Day cells — 5 rows */}
+        {Array.from({ length: 5 }).map((_, r) => (
+          <div key={r} className="grid grid-cols-7 border-b border-border last:border-b-0">
+            {Array.from({ length: 7 }).map((_, c) => (
+              <div key={c} className="h-24 px-2 pt-1.5 border-r border-border last:border-r-0 bg-background">
+                <div className="h-3 w-4 rounded bg-muted/40 mb-1.5" />
+                {r === 0 && c === 2 && <div className="h-4 rounded bg-muted/60 mb-1" />}
+                {r === 1 && c === 4 && <div className="h-4 rounded bg-muted/60 mb-1" />}
+                {r === 2 && c === 1 && <div className="h-4 rounded bg-muted/60 mb-1" />}
+                {r === 2 && c === 5 && <div className="h-4 rounded bg-muted/60" />}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 const TimeCalendarDynamic = dynamic(
   () => import("@/components/time/TimeCalendar").then((m) => m.TimeCalendar),
-  { ssr: false, loading: () => <div className="h-96 animate-pulse rounded-md bg-muted/30" /> }
+  { ssr: false, loading: () => <CalendarSkeleton /> }
 );
 
 interface Client {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fullcalendar/core": "^6.1.20",
         "@fullcalendar/daygrid": "^6.1.20",
         "@fullcalendar/interaction": "^6.1.20",
+        "@fullcalendar/list": "^6.1.20",
         "@fullcalendar/react": "^6.1.20",
         "@fullcalendar/timegrid": "^6.1.20",
         "@milkdown/crepe": "^7.19.0",
@@ -2547,6 +2548,15 @@
       "version": "6.1.20",
       "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.20.tgz",
       "integrity": "sha512-p6txmc5txL0bMiPaJxe2ip6o0T384TyoD2KGdsU6UjZ5yoBlaY+dg7kxfnYKpYMzEJLG58n+URrHr2PgNL2fyA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20"
+      }
+    },
+    "node_modules/@fullcalendar/list": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-6.1.20.tgz",
+      "integrity": "sha512-7Hzkbb7uuSqrXwTyD0Ld/7SwWNxPD6SlU548vtkIpH55rZ4qquwtwYdMPgorHos5OynHA4OUrZNcH51CjrCf2g==",
       "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.20"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fullcalendar/core": "^6.1.20",
     "@fullcalendar/daygrid": "^6.1.20",
     "@fullcalendar/interaction": "^6.1.20",
+    "@fullcalendar/list": "^6.1.20",
     "@fullcalendar/react": "^6.1.20",
     "@fullcalendar/timegrid": "^6.1.20",
     "@milkdown/crepe": "^7.19.0",


### PR DESCRIPTION
## Summary

- **Bug fix**: Removed broken `timeGridWeek` view (all events are `allDay`, so drag-drop into time slots was meaningless). Replaced with `listWeek` ("Agenda") — a clean, functional agenda view via the new `@fullcalendar/list` plugin.
- **Design**: Replaced the 100-char `[&_.fc-...]` Tailwind hack chain with a proper `.fc { --fc-* }` CSS token override block in `globals.css` (same pattern as Milkdown). Buttons, borders, today highlight, events, and the Agenda view all inherit app design tokens — dark mode adapts automatically.
- **UX**: Added a "Log time" primary button above the calendar, pre-filling today's date in the modal.
- **UX**: Per-day hour totals now appear in each day cell (e.g. `1.5h`) via `eventsSet` + `dayCellContent`.
- **Perf**: Rebuilt `loading.tsx` and the dynamic import fallback as structured calendar skeletons (toolbar + 7-column grid) to eliminate the blank-screen flash between RSC load and FullCalendar hydration.

## Test plan

- [ ] Navigate to `/time` — skeleton resembles a calendar, not a plain box
- [ ] Calendar loads with app-matched button styling and borders
- [ ] "Agenda" view button works and renders list view correctly
- [ ] "Month" and "Week" views work; dragging events between days saves correctly
- [ ] `timeGridWeek` is gone — no broken time-slot view
- [ ] Log time button opens modal with today's date pre-filled
- [ ] After logging an entry, the day cell shows the hour total (e.g. `2h`)
- [ ] Dark mode: calendar matches app theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)