### PR TITLE
feat: add start_time to time entries — real timed events on calendar

### DIFF
--- a/app/(admin)/time/list/page.tsx
+++ b/app/(admin)/time/list/page.tsx
@@ -37,7 +37,7 @@ export default async function TimeListPage({
 
   let query = supabase
     .from("time_entries")
-    .select("id, description, entry_date, duration_hours, billable, billed, hourly_rate, client_id, task_id, clients(name, color), tasks(title)")
+    .select("id, description, entry_date, start_time, duration_hours, billable, billed, hourly_rate, client_id, task_id, clients(name, color), tasks(title)")
     .order("entry_date", { ascending: false });
 
   if (params.client) query = query.eq("client_id", params.client);

--- a/app/actions/time.ts
+++ b/app/actions/time.ts
@@ -25,6 +25,7 @@ interface TimeEntryInput {
   task_id?: string | null;
   description: string;
   entry_date: string;
+  start_time?: string | null;
   duration_hours: number;
   billable: boolean;
   hourly_rate?: number | null;
@@ -60,6 +61,7 @@ export async function createTimeEntryAction(
       task_id: input.task_id || null,
       description: input.description,
       entry_date: input.entry_date,
+      start_time: input.start_time || null,
       duration_hours: input.duration_hours,
       billable: input.billable,
       hourly_rate: input.hourly_rate ?? null,
@@ -99,6 +101,7 @@ export async function updateTimeEntryAction(
       task_id: input.task_id || null,
       description: input.description,
       entry_date: input.entry_date,
+      start_time: input.start_time || null,
       duration_hours: input.duration_hours,
       billable: input.billable,
       hourly_rate: input.hourly_rate ?? null,
@@ -115,11 +118,12 @@ export async function updateTimeEntryAction(
   return {};
 }
 
-// ─── Update date (drag-drop) ──────────────────────────────────────────────────
+// ─── Update date/time (drag-drop) ────────────────────────────────────────────
 
 export async function updateTimeEntryDateAction(
   id: string,
-  entry_date: string
+  entry_date: string,
+  start_time: string | null
 ): Promise<{ error?: string }> {
   const supabase = await createClient();
   const {
@@ -132,7 +136,7 @@ export async function updateTimeEntryDateAction(
 
   const { error } = await supabase
     .from("time_entries")
-    .update({ entry_date })
+    .update({ entry_date, start_time })
     .eq("id", id);
 
   if (error) return { error: error.message };

--- a/app/api/time-entries/route.ts
+++ b/app/api/time-entries/route.ts
@@ -31,7 +31,7 @@ export async function GET(req: NextRequest) {
 
   let query = supabase
     .from("time_entries")
-    .select("id, description, entry_date, duration_hours, billable, billed, hourly_rate, client_id, task_id, clients(name, color), tasks(title)")
+    .select("id, description, entry_date, start_time, duration_hours, billable, billed, hourly_rate, client_id, task_id, clients(name, color), tasks(title)")
     .order("entry_date", { ascending: invoiceMode ? false : true });
 
   if (start) query = query.gte("entry_date", start);
@@ -53,6 +53,7 @@ export async function GET(req: NextRequest) {
         id: entry.id,
         description: entry.description,
         entry_date: entry.entry_date,
+        start_time: entry.start_time ?? null,
         duration_hours: Number(entry.duration_hours),
         billable: entry.billable,
         billed: entry.billed,
@@ -71,11 +72,30 @@ export async function GET(req: NextRequest) {
     const hours = Number(entry.duration_hours);
     const label = `${client?.name ?? "?"} · ${hours % 1 === 0 ? hours : hours.toFixed(2)}h`;
 
+    const startTime = entry.start_time as string | null;
+    const hasTimed = startTime != null;
+
+    let eventStart: string;
+    let eventEnd: string | undefined;
+
+    if (hasTimed) {
+      // startTime is "HH:MM:SS" — use "HH:MM" for the ISO datetime
+      const hhmm = startTime.substring(0, 5);
+      eventStart = `${entry.entry_date}T${hhmm}`;
+      const startMs = new Date(eventStart).getTime();
+      const endDate = new Date(startMs + hours * 3_600_000);
+      const pad = (n: number) => String(n).padStart(2, "0");
+      eventEnd = `${endDate.getFullYear()}-${pad(endDate.getMonth() + 1)}-${pad(endDate.getDate())}T${pad(endDate.getHours())}:${pad(endDate.getMinutes())}`;
+    } else {
+      eventStart = entry.entry_date;
+    }
+
     return {
       id: entry.id,
       title: `${label} — ${entry.description}`,
-      start: entry.entry_date,
-      allDay: true,
+      start: eventStart,
+      ...(eventEnd ? { end: eventEnd } : {}),
+      allDay: !hasTimed,
       backgroundColor: color,
       borderColor: color,
       textColor: "#ffffff",
@@ -88,6 +108,7 @@ export async function GET(req: NextRequest) {
         durationHours: hours,
         billable: entry.billable,
         billed: entry.billed,
+        startTime: startTime ? startTime.substring(0, 5) : null,
       },
     };
   });

--- a/app/api/time-entries/time-entries.test.ts
+++ b/app/api/time-entries/time-entries.test.ts
@@ -24,11 +24,13 @@ function makeRequest(search: Record<string, string> = {}) {
 const adminUser = { id: "user-1", app_metadata: { role: "admin" } };
 const clientUser = { id: "user-2", app_metadata: { role: "client" } };
 
+// All-day entries (no start_time)
 const TIME_ENTRIES = [
   {
     id: "te-1",
     description: "API work",
     entry_date: "2026-03-01",
+    start_time: null,
     duration_hours: "2.5",
     billable: true,
     billed: false,
@@ -42,6 +44,7 @@ const TIME_ENTRIES = [
     id: "te-2",
     description: "Meeting",
     entry_date: "2026-03-02",
+    start_time: null,
     duration_hours: "1",
     billable: true,
     billed: false,
@@ -52,6 +55,22 @@ const TIME_ENTRIES = [
     tasks: null,
   },
 ];
+
+// Timed entry (has start_time)
+const TIMED_ENTRY = {
+  id: "te-3",
+  description: "Design review",
+  entry_date: "2026-03-03",
+  start_time: "14:00:00",
+  duration_hours: "1.5",
+  billable: true,
+  billed: false,
+  hourly_rate: "150.00",
+  client_id: "client-1",
+  task_id: null,
+  clients: { name: "Acme", color: "#0969da" },
+  tasks: null,
+};
 
 /** Builds a mock Supabase query chain that resolves with the given rows. */
 function buildQueryChain(rows: unknown[], error: { message: string } | null = null) {
@@ -107,7 +126,7 @@ describe("GET /api/time-entries", () => {
     expect(json.error).toMatch(/start and end required/i);
   });
 
-  it("returns FullCalendar event objects in calendar mode (start+end)", async () => {
+  it("returns allDay FullCalendar events when entries have no start_time", async () => {
     mockGetUser.mockResolvedValueOnce({ data: { user: adminUser } });
     mockFrom.mockReturnValueOnce(buildQueryChain(TIME_ENTRIES));
 
@@ -126,13 +145,37 @@ describe("GET /api/time-entries", () => {
       allDay: true,
       backgroundColor: "#0969da",
     });
+    expect(first).not.toHaveProperty("end");
     expect(first.title).toContain("Acme");
     expect(first.title).toContain("2.50h");
     expect(first.extendedProps).toMatchObject({
       durationHours: 2.5,
       billable: true,
       billed: false,
+      startTime: null,
     });
+  });
+
+  it("returns timed FullCalendar events when entries have start_time", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: adminUser } });
+    mockFrom.mockReturnValueOnce(buildQueryChain([TIMED_ENTRY]));
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest({ start: "2026-03-01", end: "2026-03-31" }));
+    expect(res.status).toBe(200);
+    const events = await res.json();
+
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev).toMatchObject({
+      id: "te-3",
+      start: "2026-03-03T14:00",
+      allDay: false,
+    });
+    // End should be start + 1.5h = 15:30
+    expect(ev.end).toBe("2026-03-03T15:30");
+    expect(ev.extendedProps.startTime).toBe("14:00");
+    expect(ev.extendedProps.durationHours).toBe(1.5);
   });
 
   it("returns raw entry objects in invoice builder mode (client param, no dates)", async () => {
@@ -151,6 +194,7 @@ describe("GET /api/time-entries", () => {
     // Invoice mode returns raw shape — no FullCalendar-specific keys
     expect(first).toHaveProperty("id");
     expect(first).toHaveProperty("entry_date");
+    expect(first).toHaveProperty("start_time");
     expect(first).toHaveProperty("duration_hours");
     expect(first.duration_hours).toBe(2.5); // cast to Number
     expect(first).not.toHaveProperty("title");

--- a/components/time/TaskTimeEntries.tsx
+++ b/components/time/TaskTimeEntries.tsx
@@ -66,6 +66,7 @@ export function TaskTimeEntries({
       clientId,
       taskId,
       entryDate: entry.entry_date,
+      startTime: null,
       durationHours: Number(entry.duration_hours),
       billable: entry.billable,
       hourlyRate: entry.hourly_rate,

--- a/components/time/TimeCalendar.tsx
+++ b/components/time/TimeCalendar.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
+import timeGridPlugin from "@fullcalendar/timegrid";
 import listPlugin from "@fullcalendar/list";
 import interactionPlugin from "@fullcalendar/interaction";
 import type { DateClickArg } from "@fullcalendar/interaction";
@@ -31,17 +32,37 @@ interface TimeCalendarProps {
   tasks: Task[];
 }
 
+function localDateStr(d: Date) {
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, "0"),
+    String(d.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function localTimeStr(d: Date) {
+  return [
+    String(d.getHours()).padStart(2, "0"),
+    String(d.getMinutes()).padStart(2, "0"),
+  ].join(":");
+}
+
 export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
   const router = useRouter();
   const calendarRef = useRef<FullCalendar>(null);
 
   const [modalOpen, setModalOpen] = useState(false);
   const [prefillDate, setPrefillDate] = useState<string | undefined>();
+  const [prefillTime, setPrefillTime] = useState<string | undefined>();
   const [editEntry, setEditEntry] = useState<TimeEntryData | undefined>();
   const [dayHours, setDayHours] = useState<Record<string, number>>({});
 
   const fetchEvents = useCallback(
-    async (info: EventSourceFuncArg, successCallback: (events: object[]) => void, failureCallback: (error: Error) => void) => {
+    async (
+      info: EventSourceFuncArg,
+      successCallback: (events: object[]) => void,
+      failureCallback: (error: Error) => void
+    ) => {
       try {
         const start = info.startStr.split("T")[0];
         const end = info.endStr.split("T")[0];
@@ -59,43 +80,54 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
   function handleEventsSet(events: EventApi[]) {
     const totals: Record<string, number> = {};
     events.forEach((ev) => {
-      const date = ev.start?.toISOString().split("T")[0];
-      if (date) {
-        totals[date] = (totals[date] ?? 0) + ((ev.extendedProps.durationHours as number) ?? 0);
-      }
+      if (!ev.start) return;
+      // For all-day events startStr is "YYYY-MM-DD"; for timed events it's "YYYY-MM-DDTHH:MM:SS±HH:MM"
+      const date = ev.startStr.substring(0, 10);
+      totals[date] = (totals[date] ?? 0) + ((ev.extendedProps.durationHours as number) ?? 0);
     });
     setDayHours(totals);
   }
 
-  function openCreate(date?: string) {
+  function openCreate(date?: string, time?: string) {
     setEditEntry(undefined);
-    setPrefillDate(date ?? new Date().toISOString().split("T")[0]);
+    setPrefillDate(date ?? localDateStr(new Date()));
+    setPrefillTime(time ?? "");
     setModalOpen(true);
   }
 
   function handleDateClick(arg: DateClickArg) {
-    openCreate(arg.dateStr);
+    if (arg.allDay) {
+      openCreate(localDateStr(arg.date));
+    } else {
+      // Time-grid click: arg.date is the local Date at the clicked slot
+      openCreate(localDateStr(arg.date), localTimeStr(arg.date));
+    }
   }
 
   function handleEventClick(arg: EventClickArg) {
     const ep = arg.event.extendedProps;
+    const start = arg.event.start!;
     setEditEntry({
       id: arg.event.id,
       description: ep.description as string,
       clientId: ep.clientId as string,
       taskId: ep.taskId as string | null,
-      entryDate: arg.event.startStr,
+      entryDate: localDateStr(start),
+      startTime: arg.event.allDay ? null : (ep.startTime as string | null),
       durationHours: ep.durationHours as number,
       billable: ep.billable as boolean,
       hourlyRate: null,
     });
     setPrefillDate(undefined);
+    setPrefillTime(undefined);
     setModalOpen(true);
   }
 
   async function handleEventDrop(arg: EventDropArg) {
-    const newDate = arg.event.startStr;
-    const result = await updateTimeEntryDateAction(arg.event.id, newDate);
+    const start = arg.event.start!;
+    const entry_date = localDateStr(start);
+    const start_time = arg.event.allDay ? null : localTimeStr(start) + ":00";
+    const result = await updateTimeEntryDateAction(arg.event.id, entry_date, start_time);
     if (result.error) {
       arg.revert();
     }
@@ -117,15 +149,17 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
 
       <FullCalendar
         ref={calendarRef}
-        plugins={[dayGridPlugin, listPlugin, interactionPlugin]}
-        initialView="dayGridWeek"
+        plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
+        initialView="timeGridWeek"
         headerToolbar={{
           left: "prev,next today",
           center: "title",
-          right: "dayGridMonth,dayGridWeek,listWeek",
+          right: "dayGridMonth,timeGridWeek,listWeek",
         }}
         views={{
           listWeek: { buttonText: "Agenda" },
+          timeGridWeek: { buttonText: "Week" },
+          dayGridMonth: { buttonText: "Month" },
         }}
         events={fetchEvents}
         eventsSet={handleEventsSet}
@@ -134,15 +168,27 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
         dateClick={handleDateClick}
         eventClick={handleEventClick}
         height="auto"
+        scrollTime="08:00:00"
+        slotMinTime="06:00:00"
+        slotMaxTime="22:00:00"
+        slotDuration="00:30:00"
         dayMaxEvents={4}
         dayCellContent={(arg) => {
-          const dateStr = arg.date.toISOString().split("T")[0];
-          const hours = dayHours[dateStr];
+          const hours = dayHours[localDateStr(arg.date)];
           return (
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", width: "100%" }}>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "baseline",
+                width: "100%",
+              }}
+            >
               <span className="fc-daygrid-day-number">{arg.dayNumberText}</span>
               {hours != null && hours > 0 && (
-                <span className="fc-day-hours">{hours % 1 === 0 ? hours : hours.toFixed(1)}h</span>
+                <span className="fc-day-hours">
+                  {hours % 1 === 0 ? hours : hours.toFixed(1)}h
+                </span>
               )}
             </div>
           );
@@ -156,6 +202,7 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
         clients={clients}
         tasks={tasks}
         prefillDate={prefillDate}
+        prefillTime={prefillTime}
         entry={editEntry}
       />
     </>

--- a/components/time/TimeEntryList.tsx
+++ b/components/time/TimeEntryList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { TimeEntryModal, TimeEntryData } from "@/components/time/TimeEntryModal";
 import { Button } from "@/components/ui/button";
@@ -23,6 +23,7 @@ interface TimeEntry {
   id: string;
   description: string;
   entry_date: string;
+  start_time: string | null;
   duration_hours: number;
   billable: boolean;
   billed: boolean;
@@ -38,6 +39,13 @@ interface TimeEntryListProps {
   clients: Client[];
   tasks: Task[];
   totalHours: number;
+}
+
+function formatTime(t: string) {
+  const [h, m] = t.split(":").map(Number);
+  const ampm = h >= 12 ? "PM" : "AM";
+  const h12 = h % 12 || 12;
+  return `${h12}:${String(m).padStart(2, "0")} ${ampm}`;
 }
 
 export function TimeEntryList({ entries, clients, tasks, totalHours }: TimeEntryListProps) {
@@ -57,6 +65,7 @@ export function TimeEntryList({ entries, clients, tasks, totalHours }: TimeEntry
       clientId: entry.client_id,
       taskId: entry.task_id,
       entryDate: entry.entry_date,
+      startTime: entry.start_time ?? null,
       durationHours: Number(entry.duration_hours),
       billable: entry.billable,
       hourlyRate: entry.hourly_rate,
@@ -113,11 +122,16 @@ export function TimeEntryList({ entries, clients, tasks, totalHours }: TimeEntry
                     onClick={() => openEdit(entry)}
                   >
                     <td className="px-3 py-2.5 tabular-nums text-muted-foreground whitespace-nowrap">
-                      {new Date(entry.entry_date + "T00:00:00").toLocaleDateString("en-US", {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      })}
+                      <div>
+                        {new Date(entry.entry_date + "T00:00:00").toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                      </div>
+                      {entry.start_time && (
+                        <div className="text-xs mt-0.5">{formatTime(entry.start_time)}</div>
+                      )}
                     </td>
                     <td className="px-3 py-2.5">
                       <div className="flex items-center gap-1.5">

--- a/components/time/TimeEntryModal.tsx
+++ b/components/time/TimeEntryModal.tsx
@@ -26,6 +26,7 @@ export interface TimeEntryData {
   clientId: string;
   taskId: string | null;
   entryDate: string;
+  startTime: string | null;
   durationHours: number;
   billable: boolean;
   hourlyRate: number | null;
@@ -52,6 +53,7 @@ interface TimeEntryModalProps {
   tasks: Task[];
   // Pre-fill values
   prefillDate?: string;
+  prefillTime?: string;
   prefillClientId?: string;
   prefillTaskId?: string;
   // Edit mode
@@ -69,6 +71,7 @@ export function TimeEntryModal({
   clients,
   tasks,
   prefillDate,
+  prefillTime,
   prefillClientId,
   prefillTaskId,
   entry,
@@ -81,6 +84,7 @@ export function TimeEntryModal({
   const [taskId, setTaskId] = useState(entry?.taskId ?? prefillTaskId ?? "");
   const [description, setDescription] = useState(entry?.description ?? "");
   const [entryDate, setEntryDate] = useState(entry?.entryDate ?? prefillDate ?? todayISO());
+  const [startTime, setStartTime] = useState(entry?.startTime ?? prefillTime ?? "");
   const [durationHours, setDurationHours] = useState(
     entry?.durationHours != null ? String(entry.durationHours) : "1"
   );
@@ -98,6 +102,7 @@ export function TimeEntryModal({
         setTaskId(entry.taskId ?? "");
         setDescription(entry.description);
         setEntryDate(entry.entryDate);
+        setStartTime(entry.startTime ?? "");
         setDurationHours(String(entry.durationHours));
         setBillable(entry.billable);
         setHourlyRate(entry.hourlyRate != null ? String(entry.hourlyRate) : "");
@@ -106,6 +111,7 @@ export function TimeEntryModal({
         setTaskId(prefillTaskId ?? "");
         setDescription("");
         setEntryDate(prefillDate ?? todayISO());
+        setStartTime(prefillTime ?? "");
         setDurationHours("1");
         setBillable(true);
         setHourlyRate("");
@@ -138,12 +144,28 @@ export function TimeEntryModal({
 
   const clientTasks = tasks.filter((t) => t.client_id === clientId);
 
+  // Compute end time display from start + duration
+  const endTimeDisplay = (() => {
+    if (!startTime || !durationHours) return null;
+    const dur = parseFloat(durationHours);
+    if (isNaN(dur) || dur <= 0) return null;
+    const [h, m] = startTime.split(":").map(Number);
+    const totalMins = h * 60 + m + Math.round(dur * 60);
+    const endH = Math.floor(totalMins / 60) % 24;
+    const endM = totalMins % 60;
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const ampm = endH >= 12 ? "PM" : "AM";
+    const h12 = endH % 12 || 12;
+    return `${h12}:${pad(endM)} ${ampm}`;
+  })();
+
   function buildInput() {
     return {
       client_id: clientId,
       task_id: taskId || null,
       description: description.trim(),
       entry_date: entryDate,
+      start_time: startTime || null,
       duration_hours: parseFloat(durationHours) || 0,
       billable,
       hourly_rate: hourlyRate ? parseFloat(hourlyRate) : null,
@@ -250,8 +272,8 @@ export function TimeEntryModal({
             />
           </div>
 
-          {/* Date + Duration */}
-          <div className="grid grid-cols-2 gap-3">
+          {/* Date · Start · Hours */}
+          <div className="grid grid-cols-3 gap-3">
             <div className="space-y-1.5">
               <Label htmlFor="te-date">Date</Label>
               <Input
@@ -259,6 +281,17 @@ export function TimeEntryModal({
                 type="date"
                 value={entryDate}
                 onChange={(e) => setEntryDate(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="te-start">
+                Start <span className="text-muted-foreground font-normal text-xs">(opt.)</span>
+              </Label>
+              <Input
+                id="te-start"
+                type="time"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
               />
             </div>
             <div className="space-y-1.5">
@@ -274,6 +307,13 @@ export function TimeEntryModal({
               />
             </div>
           </div>
+
+          {/* End time hint */}
+          {endTimeDisplay && (
+            <p className="text-xs text-muted-foreground -mt-2">
+              Ends at {endTimeDisplay}
+            </p>
+          )}
 
           {/* Hourly rate */}
           <div className="space-y-1.5">

--- a/supabase/migrations/20260303000011_add_start_time.sql
+++ b/supabase/migrations/20260303000011_add_start_time.sql
@@ -1,0 +1,4 @@
+-- Add optional start_time to time_entries.
+-- duration_hours remains the billing source of truth.
+-- When start_time is NULL the entry is treated as all-day (legacy behaviour).
+ALTER TABLE time_entries ADD COLUMN start_time TIME;


### PR DESCRIPTION
## Summary

- **DB**: `ALTER TABLE time_entries ADD COLUMN start_time TIME` (nullable, migration `000011`). Existing all-day entries are untouched.
- **Calendar**: Default view switched to `timeGridWeek`. Clicking a time slot pre-fills start time. Drag-drop saves both date and time. Timed events appear as blocks on the grid; all-day entries float in the top strip.
- **API** (`GET /api/time-entries`): Entries with `start_time` return `{ start: "YYYY-MM-DDTHH:MM", end: start+duration, allDay: false }`. Entries without it return `{ start: "YYYY-MM-DD", allDay: true }` — fully backward-compatible. `extendedProps.startTime` exposed for edit round-trip.
- **Modal**: 3-column Date / Start (optional) / Hours layout. Live "Ends at HH:MM AM/PM" hint when both fields are filled. Start time is optional — leaving it blank logs an all-day entry.
- **List view**: Shows formatted start time (e.g. `2:00 PM`) below the date for timed entries.
- **Tests**: Updated existing all-day test (adds `start_time: null` to fixture); new test covers timed event `start`/`end`/`allDay: false` shape.

## Test plan

- [ ] Log a new time entry with a start time — it appears as a block in the week grid at the correct slot
- [ ] Log a new time entry without a start time — it appears in the all-day row
- [ ] Drag a timed event to a different slot — date and time both update in DB
- [ ] Drag an all-day entry to a different day — date updates, `start_time` remains null
- [ ] Click a time slot — modal opens with that time pre-filled
- [ ] "Ends at" hint updates live as you change start time or duration
- [ ] Edit an existing timed entry — start time is restored correctly
- [ ] List view shows `2:00 PM` below the date for timed entries, nothing for all-day
- [ ] `npm run test:unit` passes (207 tests)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)