### PR TITLE
feat: drag-to-create time entries on calendar

### DIFF
--- a/components/time/TimeCalendar.tsx
+++ b/components/time/TimeCalendar.tsx
@@ -7,7 +7,7 @@ import timeGridPlugin from "@fullcalendar/timegrid";
 import listPlugin from "@fullcalendar/list";
 import interactionPlugin from "@fullcalendar/interaction";
 import type { DateClickArg } from "@fullcalendar/interaction";
-import type { EventApi, EventClickArg, EventSourceFuncArg, EventDropArg } from "@fullcalendar/core";
+import type { EventApi, EventClickArg, EventSourceFuncArg, EventDropArg, DateSelectArg } from "@fullcalendar/core";
 import { updateTimeEntryDateAction } from "@/app/actions/time";
 import { TimeEntryModal, TimeEntryData } from "@/components/time/TimeEntryModal";
 import { Button } from "@/components/ui/button";
@@ -54,6 +54,7 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [prefillDate, setPrefillDate] = useState<string | undefined>();
   const [prefillTime, setPrefillTime] = useState<string | undefined>();
+  const [prefillDuration, setPrefillDuration] = useState<number | undefined>();
   const [editEntry, setEditEntry] = useState<TimeEntryData | undefined>();
   const [dayHours, setDayHours] = useState<Record<string, number>>({});
 
@@ -88,11 +89,22 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
     setDayHours(totals);
   }
 
-  function openCreate(date?: string, time?: string) {
+  function openCreate(date?: string, time?: string, duration?: number) {
     setEditEntry(undefined);
     setPrefillDate(date ?? localDateStr(new Date()));
     setPrefillTime(time ?? "");
+    setPrefillDuration(duration);
     setModalOpen(true);
+  }
+
+  function handleSelect(arg: DateSelectArg) {
+    const durationMs = arg.end.getTime() - arg.start.getTime();
+    const durationHours = Math.round((durationMs / 3600000) * 4) / 4;
+    if (arg.allDay) {
+      openCreate(localDateStr(arg.start), undefined, durationHours);
+    } else {
+      openCreate(localDateStr(arg.start), localTimeStr(arg.start), durationHours);
+    }
   }
 
   function handleDateClick(arg: DateClickArg) {
@@ -164,6 +176,9 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
         events={fetchEvents}
         eventsSet={handleEventsSet}
         editable={true}
+        selectable={true}
+        selectMirror={true}
+        select={handleSelect}
         eventDrop={handleEventDrop}
         dateClick={handleDateClick}
         eventClick={handleEventClick}
@@ -203,6 +218,7 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
         tasks={tasks}
         prefillDate={prefillDate}
         prefillTime={prefillTime}
+        prefillDuration={prefillDuration}
         entry={editEntry}
       />
     </>

--- a/components/time/TimeEntryModal.tsx
+++ b/components/time/TimeEntryModal.tsx
@@ -54,6 +54,7 @@ interface TimeEntryModalProps {
   // Pre-fill values
   prefillDate?: string;
   prefillTime?: string;
+  prefillDuration?: number;
   prefillClientId?: string;
   prefillTaskId?: string;
   // Edit mode
@@ -72,6 +73,7 @@ export function TimeEntryModal({
   tasks,
   prefillDate,
   prefillTime,
+  prefillDuration,
   prefillClientId,
   prefillTaskId,
   entry,
@@ -112,7 +114,7 @@ export function TimeEntryModal({
         setDescription("");
         setEntryDate(prefillDate ?? todayISO());
         setStartTime(prefillTime ?? "");
-        setDurationHours("1");
+        setDurationHours(prefillDuration != null ? String(prefillDuration) : "1");
         setBillable(true);
         setHourlyRate("");
       }


### PR DESCRIPTION
## Summary
- Add Google Calendar-style click-and-drag on empty calendar slots to create time entries
- Dragging shows a live ghost event (`selectMirror`) during the drag
- On release, the modal opens pre-filled with start date, start time, and duration computed from the drag length (rounded to nearest 0.25h)
- Adds `prefillDuration` prop to `TimeEntryModal` so the dragged duration is respected instead of defaulting to 1h

## Changes
- `components/time/TimeCalendar.tsx` — adds `selectable`, `selectMirror`, `select` props + `handleSelect` handler + `prefillDuration` state
- `components/time/TimeEntryModal.tsx` — adds `prefillDuration` prop, used in the open-reset `useEffect`

## Test plan
- [ ] In Week view, click and drag on an empty time slot — ghost event appears during drag
- [ ] On release, modal opens with date, start time, and duration pre-filled from the drag
- [ ] Save the entry — it appears on the calendar at the correct position
- [ ] Existing click-to-create (`dateClick`) still works
- [ ] Existing drag-to-reschedule (`eventDrop`) still works
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)