### PR TITLE
perf: eliminate page switching lag across the app (issue #80)

### DIFF
--- a/app/(admin)/invoices/page.tsx
+++ b/app/(admin)/invoices/page.tsx
@@ -4,47 +4,23 @@ import { createClient } from "@/lib/supabase/server";
 import { TopBar } from "@/components/layout/TopBar";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { Button } from "@/components/ui/button";
-import { InvoiceListView } from "@/components/invoices/InvoiceListView";
-import { InvoiceFilters } from "@/components/invoices/InvoiceFilters";
+import { InvoicesView } from "@/components/invoices/InvoicesView";
 import { Plus } from "lucide-react";
 
-interface SearchParams {
-  status?: string;
-  client?: string;
-}
-
-function effectiveStatus(status: string, dueDate: string | null): string {
-  if (status === "paid") return "paid";
-  if (dueDate && new Date(dueDate) < new Date() && status !== "draft") return "overdue";
-  return status;
-}
-
-export default async function InvoicesPage({
-  searchParams,
-}: {
-  searchParams: Promise<SearchParams>;
-}) {
-  const { status, client } = await searchParams;
+export default async function InvoicesPage() {
   const supabase = await createClient();
 
-  let query = supabase
-    .from("invoices")
-    .select("id, invoice_number, status, issue_date, due_date, total, clients(name, color)")
-    .order("created_at", { ascending: false });
-
-  if (client) query = query.eq("client_id", client);
-
-  const { data: invoices, error } = await query;
-
-  // Apply effective status filter client-side (overdue is computed, not stored)
-  const filtered = (invoices ?? []).filter((inv) => {
-    if (!status) return true;
-    const es = effectiveStatus(inv.status, inv.due_date);
-    return es === status;
-  });
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const typedInvoices = filtered as any[];
+  const [{ data: invoices, error }, { data: clients }] = await Promise.all([
+    supabase
+      .from("invoices")
+      .select("id, invoice_number, status, issue_date, due_date, total, client_id, clients(name, color)")
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("clients")
+      .select("id, name")
+      .eq("is_archived", false)
+      .order("name"),
+  ]);
 
   return (
     <>
@@ -60,17 +36,17 @@ export default async function InvoicesPage({
         }
       />
       <PageContainer>
-        <div className="space-y-4">
+        {error ? (
+          <p className="text-sm text-destructive">Failed to load invoices: {error.message}</p>
+        ) : (
           <Suspense fallback={null}>
-            <InvoiceFilters />
+            <InvoicesView
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              invoices={(invoices ?? []) as any}
+              clients={clients ?? []}
+            />
           </Suspense>
-
-          {error ? (
-            <p className="text-sm text-destructive">Failed to load invoices: {error.message}</p>
-          ) : (
-            <InvoiceListView invoices={typedInvoices} />
-          )}
-        </div>
+        )}
       </PageContainer>
     </>
   );

--- a/app/(admin)/tasks/page.tsx
+++ b/app/(admin)/tasks/page.tsx
@@ -4,35 +4,16 @@ import { createClient } from "@/lib/supabase/server";
 import { TopBar } from "@/components/layout/TopBar";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { Button } from "@/components/ui/button";
-import { TaskListView } from "@/components/tasks/TaskListView";
-import { TaskBoardView } from "@/components/tasks/TaskBoardView";
-import { TaskFilters } from "@/components/tasks/TaskFilters";
-import { TaskViewToggle } from "@/components/tasks/TaskViewToggle";
+import { TasksView } from "@/components/tasks/TasksView";
 import { Plus } from "lucide-react";
 
-interface SearchParams {
-  q?: string;
-  status?: string;
-  view?: string;
-}
-
-export default async function TasksPage({
-  searchParams,
-}: {
-  searchParams: Promise<SearchParams>;
-}) {
-  const { q, status, view } = await searchParams;
+export default async function TasksPage() {
   const supabase = await createClient();
 
-  let query = supabase
+  const { data: tasks, error } = await supabase
     .from("tasks")
     .select("id, task_number, title, status, priority, due_date, created_at, clients(name, color, client_key)")
     .order("created_at", { ascending: false });
-
-  if (q) query = query.ilike("title", `%${q}%`);
-  if (status) query = query.eq("status", status);
-
-  const { data: tasks, error } = await query;
 
   return (
     <>
@@ -48,26 +29,14 @@ export default async function TasksPage({
         }
       />
       <PageContainer>
-        <div className="space-y-4">
-          <div className="flex items-center justify-between gap-3">
-            <Suspense fallback={null}>
-              <TaskFilters />
-            </Suspense>
-            <Suspense fallback={null}>
-              <TaskViewToggle />
-            </Suspense>
-          </div>
-
-          {error ? (
-            <p className="text-sm text-destructive">Failed to load tasks: {error.message}</p>
-          ) : view === "board" ? (
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            <TaskBoardView tasks={(tasks ?? []) as any} />
-          ) : (
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            <TaskListView tasks={(tasks ?? []) as any} />
-          )}
-        </div>
+        {error ? (
+          <p className="text-sm text-destructive">Failed to load tasks: {error.message}</p>
+        ) : (
+          <Suspense fallback={null}>
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+            <TasksView tasks={(tasks ?? []) as any} />
+          </Suspense>
+        )}
       </PageContainer>
     </>
   );

--- a/app/(admin)/time/page.tsx
+++ b/app/(admin)/time/page.tsx
@@ -6,10 +6,71 @@ import { Button } from "@/components/ui/button";
 import { TimeCalendarWrapper } from "@/components/time/TimeCalendarWrapper";
 import { List } from "lucide-react";
 
+function dateStr(d: Date) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+// Replicate the FullCalendar event shape from /api/time-entries
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatEvents(data: any[]): object[] {
+  return data.map((entry) => {
+    const client = entry.clients as { name: string; color: string | null } | null;
+    const color = client?.color ?? "#0969da";
+    const hours = Number(entry.duration_hours);
+    const label = `${client?.name ?? "?"} · ${hours % 1 === 0 ? hours : hours.toFixed(2)}h`;
+    const startTime = entry.start_time as string | null;
+    const hasTimed = startTime != null;
+
+    let eventStart: string;
+    let eventEnd: string | undefined;
+
+    if (hasTimed) {
+      const hhmm = startTime.substring(0, 5);
+      eventStart = `${entry.entry_date}T${hhmm}`;
+      const endDate = new Date(new Date(eventStart).getTime() + hours * 3_600_000);
+      const pad = (n: number) => String(n).padStart(2, "0");
+      eventEnd = `${endDate.getFullYear()}-${pad(endDate.getMonth() + 1)}-${pad(endDate.getDate())}T${pad(endDate.getHours())}:${pad(endDate.getMinutes())}`;
+    } else {
+      eventStart = entry.entry_date;
+    }
+
+    return {
+      id: entry.id,
+      title: `${label} — ${entry.description}`,
+      start: eventStart,
+      ...(eventEnd ? { end: eventEnd } : {}),
+      allDay: !hasTimed,
+      backgroundColor: color,
+      borderColor: color,
+      textColor: "#ffffff",
+      extendedProps: {
+        description: entry.description,
+        clientId: entry.client_id,
+        clientName: client?.name ?? "",
+        clientColor: color,
+        taskId: entry.task_id,
+        durationHours: hours,
+        billable: entry.billable,
+        billed: entry.billed,
+        startTime: startTime ? startTime.substring(0, 5) : null,
+      },
+    };
+  });
+}
+
 export default async function TimePage() {
   const supabase = await createClient();
 
-  const [{ data: clients }, { data: tasks }] = await Promise.all([
+  // Current week range (Sun–Sat+1) matching FullCalendar's timeGridWeek request
+  const now = new Date();
+  const weekStart = new Date(now);
+  weekStart.setDate(now.getDate() - now.getDay());
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekStart.getDate() + 7);
+  const start = dateStr(weekStart);
+  const end = dateStr(weekEnd);
+
+  const [{ data: clients }, { data: tasks }, { data: entries }] = await Promise.all([
     supabase
       .from("clients")
       .select("id, name, color, default_rate, client_key")
@@ -20,7 +81,15 @@ export default async function TimePage() {
       .select("id, title, client_id, task_number, status")
       .not("status", "eq", "closed")
       .order("title"),
+    supabase
+      .from("time_entries")
+      .select("id, description, entry_date, start_time, duration_hours, billable, billed, hourly_rate, client_id, task_id, clients(name, color), tasks(title)")
+      .gte("entry_date", start)
+      .lte("entry_date", end)
+      .order("entry_date", { ascending: true }),
   ]);
+
+  const initialEvents = formatEvents(entries ?? []);
 
   return (
     <>
@@ -39,6 +108,7 @@ export default async function TimePage() {
         <TimeCalendarWrapper
           clients={clients ?? []}
           tasks={tasks ?? []}
+          initialEvents={initialEvents}
         />
       </PageContainer>
     </>

--- a/components/invoices/InvoiceFilters.tsx
+++ b/components/invoices/InvoiceFilters.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback } from "react";
-
 const STATUSES = [
   { value: "", label: "All" },
   { value: "draft", label: "Draft" },
@@ -12,39 +9,52 @@ const STATUSES = [
   { value: "overdue", label: "Overdue" },
 ];
 
-export function InvoiceFilters() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const status = searchParams.get("status") ?? "";
+interface Client {
+  id: string;
+  name: string;
+}
 
-  const updateParam = useCallback(
-    (key: string, value: string) => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (value) {
-        params.set(key, value);
-      } else {
-        params.delete(key);
-      }
-      router.replace(`/invoices?${params.toString()}`);
-    },
-    [router, searchParams]
-  );
+interface InvoiceFiltersProps {
+  status: string;
+  clientId: string;
+  clients: Client[];
+  onStatusChange: (status: string) => void;
+  onClientChange: (clientId: string) => void;
+}
 
+export function InvoiceFilters({ status, clientId, clients, onStatusChange, onClientChange }: InvoiceFiltersProps) {
   return (
-    <div className="flex items-center gap-1">
-      {STATUSES.map((s) => (
-        <button
-          key={s.value}
-          onClick={() => updateParam("status", s.value)}
-          className={`h-7 rounded-md px-2.5 text-xs transition-colors ${
-            status === s.value
-              ? "bg-accent text-accent-foreground font-medium"
-              : "text-muted-foreground hover:text-foreground hover:bg-muted"
-          }`}
+    <div className="flex flex-wrap items-center gap-3">
+      <div className="flex items-center gap-1">
+        {STATUSES.map((s) => (
+          <button
+            key={s.value}
+            onClick={() => onStatusChange(s.value)}
+            className={`h-7 rounded-md px-2.5 text-xs transition-colors ${
+              status === s.value
+                ? "bg-accent text-accent-foreground font-medium"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted"
+            }`}
+          >
+            {s.label}
+          </button>
+        ))}
+      </div>
+
+      {clients.length > 0 && (
+        <select
+          value={clientId || ""}
+          onChange={(e) => onClientChange(e.target.value)}
+          className="h-7 rounded-md border border-input bg-background px-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
         >
-          {s.label}
-        </button>
-      ))}
+          <option value="">All clients</option>
+          {clients.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      )}
     </div>
   );
 }

--- a/components/invoices/InvoicesView.tsx
+++ b/components/invoices/InvoicesView.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { InvoiceListView } from "./InvoiceListView";
+import { InvoiceFilters } from "./InvoiceFilters";
+
+interface Invoice {
+  id: string;
+  invoice_number: string;
+  status: string;
+  issue_date: string;
+  due_date: string | null;
+  total: number;
+  client_id: string;
+  clients: { name: string; color: string | null } | null;
+}
+
+interface Client {
+  id: string;
+  name: string;
+}
+
+function effectiveStatus(status: string, dueDate: string | null): string {
+  if (status === "paid") return "paid";
+  if (dueDate && new Date(dueDate) < new Date() && status !== "draft") return "overdue";
+  return status;
+}
+
+function syncUrl(status: string, clientId: string) {
+  const params = new URLSearchParams();
+  if (status) params.set("status", status);
+  if (clientId) params.set("client", clientId);
+  const qs = params.toString();
+  window.history.replaceState(null, "", qs ? `/invoices?${qs}` : "/invoices");
+}
+
+export function InvoicesView({ invoices, clients }: { invoices: Invoice[]; clients: Client[] }) {
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState(searchParams.get("status") ?? "");
+  const [clientId, setClientId] = useState(searchParams.get("client") ?? "");
+
+  function handleStatusChange(s: string) {
+    setStatus(s);
+    syncUrl(s, clientId);
+  }
+
+  function handleClientChange(c: string) {
+    setClientId(c);
+    syncUrl(status, c);
+  }
+
+  const filtered = invoices.filter((inv) => {
+    if (clientId && inv.client_id !== clientId) return false;
+    if (status) {
+      const es = effectiveStatus(inv.status, inv.due_date);
+      if (es !== status) return false;
+    }
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      <InvoiceFilters
+        status={status}
+        clientId={clientId}
+        clients={clients}
+        onStatusChange={handleStatusChange}
+        onClientChange={handleClientChange}
+      />
+      <InvoiceListView invoices={filtered} />
+    </div>
+  );
+}

--- a/components/layout/NavigationProgress.tsx
+++ b/components/layout/NavigationProgress.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+
+export function NavigationProgress() {
+  const pathname = usePathname();
+  const [width, setWidth] = useState(0);
+  const [visible, setVisible] = useState(false);
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const completedPathname = useRef(pathname);
+
+  function clearTimers() {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+  }
+
+  function startProgress() {
+    clearTimers();
+    setVisible(true);
+    setWidth(15);
+    timers.current.push(setTimeout(() => setWidth(40), 100));
+    timers.current.push(setTimeout(() => setWidth(65), 400));
+    timers.current.push(setTimeout(() => setWidth(80), 900));
+  }
+
+  function completeProgress() {
+    clearTimers();
+    setWidth(100);
+    timers.current.push(
+      setTimeout(() => {
+        setVisible(false);
+        setWidth(0);
+      }, 200)
+    );
+  }
+
+  // Complete when pathname changes (navigation landed)
+  useEffect(() => {
+    if (pathname !== completedPathname.current) {
+      completedPathname.current = pathname;
+      completeProgress();
+    }
+  }, [pathname]);
+
+  // Start on any internal link click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      const anchor = (e.target as HTMLElement).closest("a");
+      if (!anchor) return;
+      const href = anchor.getAttribute("href");
+      if (!href || href.startsWith("#") || href.startsWith("http") || href.startsWith("mailto")) return;
+      // Skip same-page navigations
+      try {
+        const url = new URL(href, window.location.origin);
+        if (url.pathname === window.location.pathname) return;
+      } catch {
+        return;
+      }
+      startProgress();
+    }
+
+    document.addEventListener("click", handleClick, true);
+    return () => document.removeEventListener("click", handleClick, true);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed left-0 top-0 z-[200] h-[3px] bg-primary"
+      style={{
+        width: `${width}%`,
+        transition: width === 100
+          ? "width 100ms ease-out"
+          : "width 300ms ease-in-out",
+      }}
+    />
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -28,6 +29,17 @@ const navItems = [
 
 export function Sidebar() {
   const pathname = usePathname();
+  // Optimistic active href — set immediately on click, cleared when pathname updates
+  const [pendingHref, setPendingHref] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPendingHref(null);
+  }, [pathname]);
+
+  function isActive(href: string) {
+    const check = pendingHref ?? pathname;
+    return check === href || check.startsWith(href + "/");
+  }
 
   return (
     <>
@@ -40,12 +52,13 @@ export function Sidebar() {
       {/* Primary nav */}
       <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-2">
         {navItems.map(({ href, label, icon: Icon }) => {
-          const active =
-            pathname === href || pathname.startsWith(href + "/");
+          const active = isActive(href);
           return (
             <Link
               key={href}
               href={href}
+              prefetch={true}
+              onClick={() => setPendingHref(href)}
               className={cn(
                 "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
                 active

--- a/components/layout/SidebarShell.tsx
+++ b/components/layout/SidebarShell.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { NavigationProgress } from "./NavigationProgress";
 
 interface SidebarShellProps {
   sidebar: React.ReactNode;
@@ -15,6 +16,8 @@ export function SidebarShell({ sidebar, userMenu, children }: SidebarShellProps)
 
   return (
     <div className="flex min-h-screen">
+      <NavigationProgress />
+
       {/* Mobile backdrop */}
       {mobileOpen && (
         <div

--- a/components/tasks/TaskFilters.tsx
+++ b/components/tasks/TaskFilters.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useRef } from "react";
+import { useRef } from "react";
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
 
@@ -13,30 +12,20 @@ const STATUSES = [
   { value: "closed", label: "Closed" },
 ];
 
-export function TaskFilters() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const q = searchParams.get("q") ?? "";
-  const status = searchParams.get("status") ?? "";
+interface TaskFiltersProps {
+  q: string;
+  status: string;
+  onQChange: (q: string) => void;
+  onStatusChange: (status: string) => void;
+}
 
-  const updateParam = useCallback(
-    (key: string, value: string) => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (value) {
-        params.set(key, value);
-      } else {
-        params.delete(key);
-      }
-      router.replace(`/tasks?${params.toString()}`);
-    },
-    [router, searchParams]
-  );
+export function TaskFilters({ q, status, onQChange, onStatusChange }: TaskFiltersProps) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   function handleSearch(e: React.ChangeEvent<HTMLInputElement>) {
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
-      updateParam("q", e.target.value);
+      onQChange(e.target.value);
     }, 300);
   }
 
@@ -55,7 +44,7 @@ export function TaskFilters() {
         {STATUSES.map((s) => (
           <button
             key={s.value}
-            onClick={() => updateParam("status", s.value)}
+            onClick={() => onStatusChange(s.value)}
             className={`h-7 rounded-md px-2.5 text-xs transition-colors ${
               status === s.value
                 ? "bg-accent text-accent-foreground font-medium"

--- a/components/tasks/TaskViewToggle.tsx
+++ b/components/tasks/TaskViewToggle.tsx
@@ -1,27 +1,21 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
 import { LayoutList, LayoutGrid } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-export function TaskViewToggle() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const view = searchParams.get("view") ?? "list";
+interface TaskViewToggleProps {
+  view: string;
+  onViewChange: (view: string) => void;
+}
 
-  function setView(v: string) {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("view", v);
-    router.replace(`/tasks?${params.toString()}`);
-  }
-
+export function TaskViewToggle({ view, onViewChange }: TaskViewToggleProps) {
   return (
     <div className="flex items-center rounded-md border border-border">
       <Button
         variant="ghost"
         size="sm"
         className={`h-7 rounded-r-none px-2 ${view === "list" ? "bg-accent text-accent-foreground" : "text-muted-foreground"}`}
-        onClick={() => setView("list")}
+        onClick={() => onViewChange("list")}
         title="List view"
       >
         <LayoutList className="h-3.5 w-3.5" />
@@ -30,7 +24,7 @@ export function TaskViewToggle() {
         variant="ghost"
         size="sm"
         className={`h-7 rounded-l-none border-l border-border px-2 ${view === "board" ? "bg-accent text-accent-foreground" : "text-muted-foreground"}`}
-        onClick={() => setView("board")}
+        onClick={() => onViewChange("board")}
         title="Board view"
       >
         <LayoutGrid className="h-3.5 w-3.5" />

--- a/components/tasks/TasksView.tsx
+++ b/components/tasks/TasksView.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { TaskListView } from "./TaskListView";
+import { TaskBoardView } from "./TaskBoardView";
+import { TaskFilters } from "./TaskFilters";
+import { TaskViewToggle } from "./TaskViewToggle";
+
+interface Task {
+  id: string;
+  task_number: number | null;
+  title: string;
+  status: string;
+  priority: string;
+  due_date: string | null;
+  created_at: string;
+  clients: { name: string; color: string | null; client_key: string | null } | null;
+}
+
+function syncUrl(status: string, q: string, view: string) {
+  const params = new URLSearchParams();
+  if (status) params.set("status", status);
+  if (q) params.set("q", q);
+  if (view !== "list") params.set("view", view);
+  const qs = params.toString();
+  window.history.replaceState(null, "", qs ? `/tasks?${qs}` : "/tasks");
+}
+
+export function TasksView({ tasks }: { tasks: Task[] }) {
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState(searchParams.get("status") ?? "");
+  const [q, setQ] = useState(searchParams.get("q") ?? "");
+  const [view, setView] = useState(searchParams.get("view") ?? "list");
+
+  function handleStatusChange(s: string) {
+    setStatus(s);
+    syncUrl(s, q, view);
+  }
+
+  function handleQChange(newQ: string) {
+    setQ(newQ);
+    syncUrl(status, newQ, view);
+  }
+
+  function handleViewChange(v: string) {
+    setView(v);
+    syncUrl(status, q, v);
+  }
+
+  const filtered = tasks.filter((t) => {
+    if (status && t.status !== status) return false;
+    if (q && !t.title.toLowerCase().includes(q.toLowerCase())) return false;
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <TaskFilters
+          q={q}
+          status={status}
+          onQChange={handleQChange}
+          onStatusChange={handleStatusChange}
+        />
+        <TaskViewToggle view={view} onViewChange={handleViewChange} />
+      </div>
+
+      {view === "board" ? (
+        <TaskBoardView tasks={filtered} />
+      ) : (
+        <TaskListView tasks={filtered} />
+      )}
+    </div>
+  );
+}

--- a/components/time/TimeCalendar.tsx
+++ b/components/time/TimeCalendar.tsx
@@ -33,6 +33,7 @@ interface Task {
 interface TimeCalendarProps {
   clients: Client[];
   tasks: Task[];
+  initialEvents: object[];
 }
 
 function localDateStr(d: Date) {
@@ -50,9 +51,11 @@ function localTimeStr(d: Date) {
   ].join(":");
 }
 
-export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
+export function TimeCalendar({ clients, tasks, initialEvents }: TimeCalendarProps) {
   const router = useRouter();
   const calendarRef = useRef<FullCalendar>(null);
+  const isFirstFetch = useRef(true);
+  const initialEventsRef = useRef(initialEvents);
 
   const [modalOpen, setModalOpen] = useState(false);
   const [prefillDate, setPrefillDate] = useState<string | undefined>();
@@ -67,6 +70,13 @@ export function TimeCalendar({ clients, tasks }: TimeCalendarProps) {
       successCallback: (events: object[]) => void,
       failureCallback: (error: Error) => void
     ) => {
+      // On the very first fetch, return the server-prefetched events immediately
+      // so the calendar renders without waiting for an API round-trip.
+      if (isFirstFetch.current) {
+        isFirstFetch.current = false;
+        successCallback(initialEventsRef.current);
+        return;
+      }
       try {
         const start = info.startStr.split("T")[0];
         const end = info.endStr.split("T")[0];

--- a/components/time/TimeCalendarWrapper.tsx
+++ b/components/time/TimeCalendarWrapper.tsx
@@ -69,6 +69,12 @@ interface Task {
   status: string;
 }
 
-export function TimeCalendarWrapper({ clients, tasks }: { clients: Client[]; tasks: Task[] }) {
-  return <TimeCalendarDynamic clients={clients} tasks={tasks} />;
+interface TimeCalendarWrapperProps {
+  clients: Client[];
+  tasks: Task[];
+  initialEvents: object[];
+}
+
+export function TimeCalendarWrapper({ clients, tasks, initialEvents }: TimeCalendarWrapperProps) {
+  return <TimeCalendarDynamic clients={clients} tasks={tasks} initialEvents={initialEvents} />;
 }

--- a/components/time/TimeFilters.tsx
+++ b/components/time/TimeFilters.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTransition } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 import {
@@ -26,6 +27,7 @@ export function TimeFilters({ clients }: TimeFiltersProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
 
   const clientId = searchParams.get("client") ?? "";
   const startDate = searchParams.get("start") ?? "";
@@ -41,7 +43,9 @@ export function TimeFilters({ clients }: TimeFiltersProps) {
       } else {
         params.delete(key);
       }
-      router.replace(`${pathname}?${params.toString()}`);
+      startTransition(() => {
+        router.replace(`${pathname}?${params.toString()}`);
+      });
     },
     [router, pathname, searchParams]
   );
@@ -49,11 +53,13 @@ export function TimeFilters({ clients }: TimeFiltersProps) {
   const hasFilters = clientId || startDate || endDate || billable !== "all" || billed !== "all";
 
   function clearAll() {
-    router.replace(pathname);
+    startTransition(() => {
+      router.replace(pathname);
+    });
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-2 mb-4">
+    <div className={`flex flex-wrap items-center gap-2 mb-4 transition-opacity ${isPending ? "opacity-60" : ""}`}>
       <Select value={clientId || "all"} onValueChange={(v) => updateParam("client", v === "all" ? "" : v)}>
         <SelectTrigger className="h-7 text-xs w-40">
           <SelectValue placeholder="All clients" />


### PR DESCRIPTION
## Summary

- **Sidebar prefetch + optimistic highlight** — `prefetch={true}` on all nav links eagerly caches RSC payloads; active item highlights instantly on click via `pendingHref` state (clears when `usePathname()` confirms navigation)
- **Navigation progress bar** — 3px `bg-primary` bar pinned to the top of the viewport; appears the moment any internal link is clicked, completes when the new page lands
- **Tasks page — full issue #80 pattern** — server fetches all tasks once; new `TasksView` client component owns `status`/`q`/`view` state with `useState`, filters in-memory, syncs URL via `window.history.replaceState`; `TaskFilters` and `TaskViewToggle` are now prop-driven with no `useSearchParams`
- **Invoices page — full issue #80 pattern** — server fetches all invoices + clients; new `InvoicesView` client component owns `status`/`client` filters; `InvoiceFilters` uses a native `<select>` for the client dropdown (avoids Radix `aria-controls` hydration mismatch on dynamic pages)
- **Time list — `useTransition` upgrade** — all `router.replace()` calls in `TimeFilters` wrapped in `startTransition()`; existing table stays visible and dims slightly while the server re-fetches
- **Time calendar — server-prefetched initial events** — `time/page.tsx` now fetches the current week's entries in parallel with clients/tasks; `TimeCalendar` returns them synchronously on the first `fetchEvents` call, eliminating the post-render API round-trip that delayed event display

## Test plan

- [ ] Click between sidebar items — highlight changes instantly, progress bar appears and completes
- [ ] Tasks: type in search, click status tabs, toggle list/board — all instant, no network requests visible for filter changes
- [ ] Invoices: click status filters, change client dropdown — instant
- [ ] Time list: change client/billable/billed filters — table stays visible, dims briefly; date range changes refetch without flash
- [ ] Time calendar: navigate to `/time` — events appear as soon as the calendar renders (no second loading phase); navigate to a different week — events fetch from API normally
- [ ] `npm run build` passes clean

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)