### PR TITLE
feat: overhaul invoice PDF layout and line-item grouping by task

### DIFF
--- a/app/(admin)/invoices/[invoiceId]/edit/page.tsx
+++ b/app/(admin)/invoices/[invoiceId]/edit/page.tsx
@@ -63,6 +63,8 @@ export default async function EditInvoicePage({
       sort_order: li.sort_order,
       time_entry_id: li.time_entry_id,
       imported: li.time_entry_id !== null,
+      taskId: null,
+      importedEntryIds: li.time_entry_id ? [li.time_entry_id] : [],
     }));
 
   const boundAction = updateInvoiceAction.bind(null, invoiceId);

--- a/app/(admin)/invoices/new/InvoiceBuilderClient.tsx
+++ b/app/(admin)/invoices/new/InvoiceBuilderClient.tsx
@@ -35,8 +35,10 @@ interface TimeEntry {
   billable: boolean;
   billed: boolean;
   hourly_rate: number | null;
+  client_id: string;
+  task_id: string | null;
   clients: { name: string } | null;
-  tasks: { title: string } | null;
+  tasks: { title: string; task_number: number | null; clients: { client_key: string } | null } | null;
 }
 
 interface LineItem {
@@ -48,6 +50,8 @@ interface LineItem {
   sort_order: number;
   time_entry_id: string | null;
   imported: boolean; // true = came from a time entry
+  taskId: string | null; // task UUID this line item represents (null = manual or no-task entry)
+  importedEntryIds: string[]; // time entry IDs rolled into this line item
 }
 
 interface InvoiceBuilderClientProps {
@@ -196,38 +200,98 @@ export function InvoiceBuilderClient({
         sort_order: prev.length,
         time_entry_id: null,
         imported: false,
+        taskId: null,
+        importedEntryIds: [],
       },
     ]);
   }, [clients, selectedClientId]);
 
   const isEntryImported = useCallback(
-    (entryId: string) => lineItems.some((li) => li.time_entry_id === entryId),
+    (entryId: string) => lineItems.some((li) => li.importedEntryIds.includes(entryId)),
     [lineItems]
   );
 
   const toggleTimeEntry = useCallback(
     (entry: TimeEntry) => {
-      if (isEntryImported(entry.id)) {
-        setLineItems((prev) => prev.filter((li) => li.time_entry_id !== entry.id));
+      const rate = entry.hourly_rate ?? clients.find((c) => c.id === selectedClientId)?.default_rate ?? 0;
+      const qty = Number(entry.duration_hours);
+
+      if (entry.task_id) {
+        // Group by task: find existing line item for this task
+        const existingLi = lineItems.find((li) => li.taskId === entry.task_id);
+        if (existingLi) {
+          if (existingLi.importedEntryIds.includes(entry.id)) {
+            // Deselect: remove this entry's hours from the task line item
+            const newIds = existingLi.importedEntryIds.filter((id) => id !== entry.id);
+            if (newIds.length === 0) {
+              setLineItems((prev) => prev.filter((li) => li.key !== existingLi.key));
+            } else {
+              setLineItems((prev) =>
+                prev.map((li) => {
+                  if (li.key !== existingLi.key) return li;
+                  const newQty = li.quantity - qty;
+                  return { ...li, quantity: newQty, amount: newQty * li.unit_price, importedEntryIds: newIds };
+                })
+              );
+            }
+          } else {
+            // Select: add this entry's hours to existing task line item
+            setLineItems((prev) =>
+              prev.map((li) => {
+                if (li.key !== existingLi.key) return li;
+                const newQty = li.quantity + qty;
+                return { ...li, quantity: newQty, amount: newQty * li.unit_price, importedEntryIds: [...li.importedEntryIds, entry.id] };
+              })
+            );
+          }
+        } else {
+          // No line item for this task yet — create one
+          const task = entry.tasks;
+          const taskKey =
+            task?.clients?.client_key && task.task_number != null
+              ? `${task.clients.client_key}-${task.task_number}`
+              : null;
+          const desc = taskKey ? `${taskKey}: ${task!.title}` : (task?.title ?? entry.description);
+          setLineItems((prev) => [
+            ...prev,
+            {
+              key: nextKey(),
+              description: desc,
+              quantity: qty,
+              unit_price: rate,
+              amount: qty * rate,
+              sort_order: prev.length,
+              time_entry_id: null,
+              imported: true,
+              taskId: entry.task_id,
+              importedEntryIds: [entry.id],
+            },
+          ]);
+        }
       } else {
-        const rate = entry.hourly_rate ?? clients.find((c) => c.id === selectedClientId)?.default_rate ?? 0;
-        const qty = Number(entry.duration_hours);
-        setLineItems((prev) => [
-          ...prev,
-          {
-            key: nextKey(),
-            description: entry.description,
-            quantity: qty,
-            unit_price: rate,
-            amount: qty * rate,
-            sort_order: prev.length,
-            time_entry_id: entry.id,
-            imported: true,
-          },
-        ]);
+        // No task: one line item per entry (original behavior)
+        if (isEntryImported(entry.id)) {
+          setLineItems((prev) => prev.filter((li) => !li.importedEntryIds.includes(entry.id)));
+        } else {
+          setLineItems((prev) => [
+            ...prev,
+            {
+              key: nextKey(),
+              description: entry.description,
+              quantity: qty,
+              unit_price: rate,
+              amount: qty * rate,
+              sort_order: prev.length,
+              time_entry_id: entry.id,
+              imported: true,
+              taskId: null,
+              importedEntryIds: [entry.id],
+            },
+          ]);
+        }
       }
     },
-    [clients, isEntryImported, selectedClientId]
+    [clients, isEntryImported, lineItems, selectedClientId]
   );
 
   const lineItemsJson = JSON.stringify(

--- a/app/api/time-entries/route.ts
+++ b/app/api/time-entries/route.ts
@@ -31,7 +31,7 @@ export async function GET(req: NextRequest) {
 
   let query = supabase
     .from("time_entries")
-    .select("id, description, entry_date, start_time, duration_hours, billable, billed, hourly_rate, client_id, task_id, clients(name, color), tasks(title)")
+    .select("id, description, entry_date, start_time, duration_hours, billable, billed, hourly_rate, client_id, task_id, clients(name, color), tasks(title, task_number, clients(client_key))")
     .order("entry_date", { ascending: invoiceMode ? false : true });
 
   if (start) query = query.gte("entry_date", start);

--- a/app/api/time-entries/time-entries.test.ts
+++ b/app/api/time-entries/time-entries.test.ts
@@ -38,7 +38,7 @@ const TIME_ENTRIES = [
     client_id: "client-1",
     task_id: "task-1",
     clients: { name: "Acme", color: "#0969da" },
-    tasks: { title: "Fix bug" },
+    tasks: { title: "Fix bug", task_number: 1, clients: { client_key: "AC" } },
   },
   {
     id: "te-2",

--- a/components/invoices/InvoicePDF.tsx
+++ b/components/invoices/InvoicePDF.tsx
@@ -98,12 +98,20 @@ const styles = StyleSheet.create({
     lineHeight: 1.5,
   },
   // Header
-  header: { flexDirection: "row", justifyContent: "space-between", marginBottom: 32 },
-  businessName: { fontSize: 14, fontWeight: 700, color: ACCENT },
-  businessInfo: { fontSize: 8, color: GRAY, marginTop: 4 },
-  invoiceTitle: { fontSize: 22, fontWeight: 700, color: "#1f2328", textAlign: "right" },
-  invoiceMeta: { fontSize: 8, color: GRAY, textAlign: "right", marginTop: 4 },
-  invoiceNumber: { fontSize: 10, fontWeight: 700, color: ACCENT, textAlign: "right", marginTop: 2 },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingBottom: 32,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+    marginBottom: 28,
+  },
+  businessName: { fontSize: 18, fontWeight: 700, color: ACCENT, marginBottom: 8 },
+  businessInfoBlock: { gap: 3 },
+  businessContactBlock: { gap: 3, marginTop: 8 },
+  businessInfo: { fontSize: 9, color: "#4a5565", lineHeight: 1.4 },
+  invoiceTitle: { fontSize: 27, fontWeight: 700, color: "#101828", textAlign: "right" },
+  invoiceNumber: { fontSize: 9, color: GRAY, textAlign: "right", marginTop: 6 },
   // Bill-to
   billToSection: { flexDirection: "row", marginBottom: 28 },
   billToBlock: { flex: 1 },
@@ -133,6 +141,7 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     paddingHorizontal: 8,
   },
+  colNum: { width: 20, textAlign: "right", marginRight: 8 },
   colDesc: { flex: 1 },
   colQty: { width: 50, textAlign: "right" },
   colRate: { width: 70, textAlign: "right" },
@@ -157,13 +166,20 @@ const styles = StyleSheet.create({
   totalLabelBold: { fontSize: 10, fontWeight: 700 },
   totalValueBold: { fontSize: 10, fontWeight: 700, color: ACCENT },
   // Memo
-  memoSection: { marginBottom: 24 },
+  memoSection: {
+    marginBottom: 24,
+    borderTopWidth: 1,
+    borderColor: BORDER,
+    paddingTop: 12,
+  },
   memoLabel: { fontSize: 7, fontWeight: 700, color: GRAY, textTransform: "uppercase", letterSpacing: 0.5, marginBottom: 4 },
   memoText: { fontSize: 8, color: GRAY },
   // Footer
   footer: { borderTopWidth: 1, borderColor: BORDER, paddingTop: 12, marginTop: "auto" },
   footerText: { fontSize: 7, color: GRAY, textAlign: "center" },
+  pageNumber: { fontSize: 7, color: GRAY, textAlign: "center", marginTop: 2 },
 });
+
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -192,13 +208,14 @@ export function InvoicePDF({ invoice, settings }: InvoicePDFProps) {
   }
   if (addr?.country && addr.country !== "US") billingLines.push(addr.country);
 
-  const businessLines: string[] = [];
-  if (settings.address_line1) businessLines.push(settings.address_line1);
-  if (settings.address_line2) businessLines.push(settings.address_line2);
+  const businessAddrLines: string[] = [];
+  if (settings.address_line1) businessAddrLines.push(settings.address_line1);
+  if (settings.address_line2) businessAddrLines.push(settings.address_line2);
   const cityLine = [settings.city, settings.state, settings.postal_code].filter(Boolean).join(", ");
-  if (cityLine) businessLines.push(cityLine);
-  if (settings.email) businessLines.push(settings.email);
-  if (settings.phone) businessLines.push(settings.phone);
+  if (cityLine) businessAddrLines.push(cityLine);
+  const businessContactLines: string[] = [];
+  if (settings.email) businessContactLines.push(settings.email);
+  if (settings.phone) businessContactLines.push(settings.phone);
 
   const sortedItems = [...invoice.invoice_line_items].sort((a, b) => a.sort_order - b.sort_order);
   const subtotal = Number(invoice.subtotal);
@@ -222,16 +239,24 @@ export function InvoicePDF({ invoice, settings }: InvoicePDFProps) {
         <View style={styles.header}>
           <View>
             <Text style={styles.businessName}>{settings.business_name ?? "Your Business"}</Text>
-            {businessLines.map((line, i) => (
-              <Text key={i} style={styles.businessInfo}>{line}</Text>
-            ))}
+            {businessAddrLines.length > 0 && (
+              <View style={styles.businessInfoBlock}>
+                {businessAddrLines.map((line, i) => (
+                  <Text key={i} style={styles.businessInfo}>{line}</Text>
+                ))}
+              </View>
+            )}
+            {businessContactLines.length > 0 && (
+              <View style={styles.businessContactBlock}>
+                {businessContactLines.map((line, i) => (
+                  <Text key={i} style={styles.businessInfo}>{line}</Text>
+                ))}
+              </View>
+            )}
           </View>
           <View>
             <Text style={styles.invoiceTitle}>INVOICE</Text>
             <Text style={styles.invoiceNumber}>{invoice.invoice_number}</Text>
-            <Text style={styles.invoiceMeta}>
-              {invoice.status.charAt(0).toUpperCase() + invoice.status.slice(1)}
-            </Text>
           </View>
         </View>
 
@@ -262,14 +287,20 @@ export function InvoicePDF({ invoice, settings }: InvoicePDFProps) {
         {/* Line items */}
         <View style={styles.table}>
           <View style={styles.tableHeader}>
-            <Text style={[styles.thText, styles.colDesc]}>Description</Text>
+            <Text style={[styles.thText, styles.colNum]}>#</Text>
+            <View style={styles.colDesc}>
+              <Text style={styles.thText}>Description</Text>
+            </View>
             <Text style={[styles.thText, styles.colQty]}>Qty</Text>
             <Text style={[styles.thText, styles.colRate]}>Rate</Text>
             <Text style={[styles.thText, styles.colAmount]}>Amount</Text>
           </View>
           {sortedItems.map((item, i) => (
             <View key={i} style={styles.tableRow}>
-              <Text style={[styles.tdText, styles.colDesc]}>{item.description}</Text>
+              <Text style={[styles.tdText, styles.colNum]}>{i + 1}</Text>
+              <View style={styles.colDesc}>
+                <Text style={styles.tdText}>{item.description}</Text>
+              </View>
               <Text style={[styles.tdText, styles.colQty]}>{Number(item.quantity).toFixed(2)}</Text>
               <Text style={[styles.tdText, styles.colRate]}>{currency(Number(item.unit_price))}</Text>
               <Text style={[styles.tdText, styles.colAmount]}>{currency(Number(item.amount))}</Text>
@@ -332,6 +363,12 @@ export function InvoicePDF({ invoice, settings }: InvoicePDFProps) {
           <Text style={styles.footerText}>
             {settings.business_name ?? "Your Business"} · {invoice.invoice_number} · Thank you for your business.
           </Text>
+          <Text
+            style={styles.pageNumber}
+            render={({ pageNumber, totalPages }) =>
+              totalPages > 1 ? `Page ${pageNumber} of ${totalPages}` : ""
+            }
+          />
         </View>
       </Page>
     </Document>


### PR DESCRIPTION
## Summary

- **PDF header redesign** — matches Figma mockup: business name 18pt bold blue, address and contact lines in separate blocks with consistent 3pt gap and 8pt break between groups, bottom border divider, INVOICE 27pt near-black with invoice number as a small gray subtitle beneath
- **Description wrapping fixed** — descriptions in line items now wrap instead of truncating (Text wrapped in flex View)
- **Line items grouped by task** — importing time entries in the invoice builder now creates one line item per task (total hours × rate), labeled `{CLIENT_KEY}-{task_number}: {title}`. Entries without a task remain one-per-entry. Multiple entries for the same task are accumulated — checking/unchecking adjusts the qty on the shared line item
- **Sequential # column** added to line items table for client reference
- **Notes section** gets a top border separator from the footer
- **Page X of Y** footer rendered on multi-page invoices
- Status badge removed per design decision

## Test plan

- [ ] Open an existing invoice PDF — confirm header matches Figma layout (business name, grouped address/contact, INVOICE dominant, invoice number below)
- [ ] Confirm line item descriptions wrap fully with no truncation
- [ ] Create a new invoice, import time entries linked to the same task — confirm they merge into one line item with summed hours
- [ ] Import an entry with no task — confirm it gets its own line item
- [ ] Uncheck an imported entry — confirm hours are subtracted (or line item removed if last entry)
- [ ] `npm run build` passes ✅
- [ ] `npm run test:unit` — 207 tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)