### PR TITLE
feat: client portal — task requests, invoices, and auth fix

### DIFF
--- a/app/actions/portal.ts
+++ b/app/actions/portal.ts
@@ -1,4 +1,6 @@
 "use server";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Resend } from "resend";
@@ -84,7 +86,7 @@ export async function sendPortalSignInLinkAction(
     type: "magiclink",
     email: client.email,
     options: {
-      redirectTo: `${appUrl}/auth/callback?next=/portal/${tenant.slug}`,
+      redirectTo: `${appUrl}/portal/${tenant.slug}/auth-callback`,
     },
   });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -130,6 +132,172 @@ export async function sendPortalSignInLinkAction(
 
   if (sendError) return { error: (sendError as Error).message };
   return { success: true };
+}
+
+// ─── Finalize portal session (called client-side after hash-fragment auth) ───
+//
+// Admin-generated magic links use the OTP/implicit flow: Supabase redirects
+// back with access_token in the URL hash, NOT a code parameter.  The browser
+// Supabase client detects the hash, stores the session in cookies, and then
+// the PortalAuthCallbackClient calls this action to create the profile row
+// (first-time sign-in) or verify the existing one (returning user).
+
+export async function finalizePortalSessionAction(
+  tenantSlug: string
+): Promise<{ error?: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { error: "No session found." };
+
+  // Check for an existing profile (returning user)
+  const { data: existingProfile } = await supabase
+    .from("profiles")
+    .select("id, role")
+    .eq("id", user.id)
+    .single();
+
+  if (existingProfile) {
+    if (existingProfile.role !== "client") {
+      await supabase.auth.signOut();
+      return { error: "Unauthorized." };
+    }
+    return {}; // Returning client — nothing to set up
+  }
+
+  // First-time sign-in: set up the portal account
+  const admin = createAdminClient();
+
+  const { data: tenant } = await admin
+    .from("tenants")
+    .select("id, slug")
+    .eq("slug", tenantSlug)
+    .single();
+
+  if (!tenant) {
+    await supabase.auth.signOut();
+    return { error: "Tenant not found." };
+  }
+
+  // Match the user's email to a clients record in this tenant
+  const { data: client } = await admin
+    .from("clients")
+    .select("id")
+    .eq("email", user.email!)
+    .eq("tenant_id", tenant.id)
+    .single();
+
+  if (!client) {
+    await supabase.auth.signOut();
+    return { error: "not_invited" };
+  }
+
+  const displayName =
+    user.user_metadata?.full_name ??
+    user.user_metadata?.name ??
+    user.email?.split("@")[0] ??
+    "Client";
+
+  await admin.from("profiles").insert({
+    id: user.id,
+    tenant_id: tenant.id,
+    role: "client",
+    full_name: displayName,
+  });
+
+  // Update the pending access row (if it exists) or create a new one
+  const { data: existingAccess } = await admin
+    .from("client_portal_access")
+    .select("id")
+    .eq("client_id", client.id)
+    .eq("tenant_id", tenant.id)
+    .maybeSingle();
+
+  if (existingAccess) {
+    await admin
+      .from("client_portal_access")
+      .update({ user_id: user.id, accepted_at: new Date().toISOString() })
+      .eq("client_id", client.id)
+      .eq("tenant_id", tenant.id);
+  } else {
+    await admin.from("client_portal_access").insert({
+      tenant_id: tenant.id,
+      client_id: client.id,
+      user_id: user.id,
+      accepted_at: new Date().toISOString(),
+    });
+  }
+
+  await admin.auth.admin.updateUserById(user.id, {
+    app_metadata: {
+      role: "client",
+      tenant_id: tenant.id,
+      tenant_slug: tenant.slug,
+    },
+  });
+
+  return {};
+}
+
+// ─── Create task from portal (client role) ───────────────────────────────────
+
+/**
+ * Allows a portal client to submit a new task request.
+ * tenantSlug is bound at call-site via .bind() so we can redirect back to the portal.
+ */
+export async function createPortalTaskAction(
+  tenantSlug: string,
+  _prev: { error?: string } | null,
+  formData: FormData
+): Promise<{ error?: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user || user.app_metadata?.role !== "client") {
+    return { error: "Unauthorized." };
+  }
+
+  const tenantId = user.app_metadata?.tenant_id as string | undefined;
+  if (!tenantId) return { error: "No tenant found." };
+
+  const { data: access } = await supabase
+    .from("client_portal_access")
+    .select("client_id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (!access?.client_id) return { error: "Portal access not found." };
+
+  const title = (formData.get("title") as string)?.trim();
+  if (!title) return { error: "Title is required." };
+
+  const admin = createAdminClient();
+
+  const { data: taskNumber, error: numError } = await admin.rpc(
+    "next_task_number_for_client",
+    { p_client_id: access.client_id }
+  );
+  if (numError) return { error: numError.message };
+
+  const { data, error } = await admin
+    .from("tasks")
+    .insert({
+      tenant_id: tenantId,
+      client_id: access.client_id,
+      title,
+      task_number: taskNumber,
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) return { error: error?.message ?? "Failed to create task." };
+
+  revalidatePath(`/portal/${tenantSlug}`);
+  redirect(`/portal/${tenantSlug}/tasks/${data.id}`);
 }
 
 export async function revokePortalAccessAction(

--- a/app/portal/[tenantSlug]/(protected)/invoices/page.tsx
+++ b/app/portal/[tenantSlug]/(protected)/invoices/page.tsx
@@ -1,0 +1,155 @@
+import { createClient, getCachedUser } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getImpersonationPayload } from "@/lib/portal/impersonation";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+function formatDate(d: string | null) {
+  if (!d) return "—";
+  return new Date(d).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatCurrency(amount: number, currency = "USD") {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(amount);
+}
+
+const STATUS_CONFIG = {
+  sent: { label: "Sent", className: "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-400 dark:border-blue-900" },
+  viewed: { label: "Viewed", className: "bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950 dark:text-sky-400 dark:border-sky-900" },
+  paid: { label: "Paid", className: "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-400 dark:border-emerald-900" },
+  overdue: { label: "Overdue", className: "bg-red-50 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-400 dark:border-red-900" },
+} as const;
+
+function invoiceDisplayStatus(invoice: { status: string; due_date: string | null }) {
+  if (invoice.status === "paid") return "paid";
+  if (
+    invoice.due_date &&
+    invoice.status !== "paid" &&
+    new Date(invoice.due_date) < new Date()
+  ) {
+    return "overdue";
+  }
+  return invoice.status as "sent" | "viewed";
+}
+
+export default async function PortalInvoicesPage({
+  params,
+}: {
+  params: Promise<{ tenantSlug: string }>;
+}) {
+  const { tenantSlug } = await params;
+
+  const [user, supabase, impersonation] = await Promise.all([
+    getCachedUser(),
+    createClient(),
+    getImpersonationPayload(),
+  ]);
+
+  const admin = createAdminClient();
+  const isImpersonating = !!impersonation && impersonation.tenantSlug === tenantSlug;
+
+  let clientId: string | undefined;
+
+  if (isImpersonating) {
+    clientId = impersonation!.clientId;
+  } else {
+    const { data: access } = await supabase
+      .from("client_portal_access")
+      .select("client_id")
+      .eq("user_id", user!.id)
+      .single();
+    clientId = access?.client_id;
+  }
+
+  const db = isImpersonating ? admin : supabase;
+
+  const { data: invoices } = clientId
+    ? await db
+        .from("invoices")
+        .select("id, invoice_number, status, issue_date, due_date, total, amount_paid")
+        .eq("client_id", clientId)
+        .order("issue_date", { ascending: false })
+    : { data: [] };
+
+  // Mark any "sent" invoices as "viewed" now that the client has opened this page
+  if (!isImpersonating && invoices?.some((i) => i.status === "sent")) {
+    const sentIds = invoices!.filter((i) => i.status === "sent").map((i) => i.id);
+    await admin
+      .from("invoices")
+      .update({ status: "viewed", viewed_at: new Date().toISOString() })
+      .in("id", sentIds);
+    // Reflect update locally so the badges show "viewed"
+    for (const inv of invoices!) {
+      if (inv.status === "sent") inv.status = "viewed";
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-lg font-semibold">Invoices</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Invoices your consultant has sent you.
+        </p>
+      </div>
+
+      {!invoices?.length ? (
+        <div className="rounded-md border border-dashed border-border p-8 text-center">
+          <p className="text-sm text-muted-foreground">No invoices yet.</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-border rounded-md border border-border">
+          {invoices.map((invoice) => {
+            const displayStatus = invoiceDisplayStatus(invoice);
+            const config =
+              STATUS_CONFIG[displayStatus] ??
+              STATUS_CONFIG.sent;
+            const outstanding =
+              invoice.status !== "paid"
+                ? Number(invoice.total) - Number(invoice.amount_paid ?? 0)
+                : 0;
+
+            return (
+              <div
+                key={invoice.id}
+                className="flex items-center gap-4 px-4 py-3"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-foreground">
+                    {invoice.invoice_number}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Issued {formatDate(invoice.issue_date)}
+                    {invoice.due_date && ` · Due ${formatDate(invoice.due_date)}`}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3 shrink-0">
+                  <div className="text-right">
+                    <p className="text-sm font-medium tabular-nums">
+                      {formatCurrency(Number(invoice.total))}
+                    </p>
+                    {outstanding > 0 && invoice.status !== "paid" && (
+                      <p className={cn("text-xs tabular-nums", displayStatus === "overdue" ? "text-red-600 dark:text-red-400" : "text-muted-foreground")}>
+                        {formatCurrency(outstanding)} due
+                      </p>
+                    )}
+                  </div>
+                  <Badge variant="outline" className={cn("text-xs", config.className)}>
+                    {config.label}
+                  </Badge>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/portal/[tenantSlug]/(protected)/layout.tsx
+++ b/app/portal/[tenantSlug]/(protected)/layout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient, getCachedUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -66,9 +67,25 @@ export default async function PortalLayout({
       )}
       <header className="border-b border-border bg-background/95 backdrop-blur sticky top-0 z-10">
         <div className="mx-auto max-w-4xl px-6 h-12 flex items-center justify-between">
-          <span className="text-sm font-semibold text-foreground">
-            {businessName}
-          </span>
+          <div className="flex items-center gap-6">
+            <span className="text-sm font-semibold text-foreground">
+              {businessName}
+            </span>
+            <nav className="flex items-center gap-1">
+              <Link
+                href={`/portal/${tenantSlug}`}
+                className="text-sm px-2.5 py-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
+              >
+                Tasks
+              </Link>
+              <Link
+                href={`/portal/${tenantSlug}/invoices`}
+                className="text-sm px-2.5 py-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
+              >
+                Invoices
+              </Link>
+            </nav>
+          </div>
           {!isImpersonating && <PortalSignOutButton tenantSlug={tenantSlug} />}
         </div>
       </header>

--- a/app/portal/[tenantSlug]/(protected)/page.tsx
+++ b/app/portal/[tenantSlug]/(protected)/page.tsx
@@ -3,6 +3,7 @@ import { createClient, getCachedUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getImpersonationPayload } from "@/lib/portal/impersonation";
 import { TaskStatusBadge, TaskPriorityBadge } from "@/components/tasks/TaskStatusBadge";
+import { PortalCreateTaskDialog } from "@/components/portal/PortalCreateTaskDialog";
 
 function formatDate(d: string | null) {
   if (!d) return null;
@@ -70,11 +71,14 @@ export default async function PortalDashboardPage({
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-lg font-semibold">Your Tasks</h1>
-        <p className="text-sm text-muted-foreground mt-0.5">
-          View and track the tasks your consultant is working on.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-lg font-semibold">Your Tasks</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            View and track the tasks your consultant is working on.
+          </p>
+        </div>
+        {!isImpersonating && <PortalCreateTaskDialog tenantSlug={tenantSlug} />}
       </div>
 
       {!tasks?.length ? (

--- a/app/portal/[tenantSlug]/auth-callback/page.tsx
+++ b/app/portal/[tenantSlug]/auth-callback/page.tsx
@@ -1,0 +1,10 @@
+import { PortalAuthCallbackClient } from "@/components/portal/PortalAuthCallbackClient";
+
+export default async function PortalAuthCallbackPage({
+  params,
+}: {
+  params: Promise<{ tenantSlug: string }>;
+}) {
+  const { tenantSlug } = await params;
+  return <PortalAuthCallbackClient tenantSlug={tenantSlug} />;
+}

--- a/components/portal/PortalAuthCallbackClient.tsx
+++ b/components/portal/PortalAuthCallbackClient.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { finalizePortalSessionAction } from "@/app/actions/portal";
+
+/**
+ * Handles the implicit-flow (hash-fragment) auth callback for admin-generated
+ * portal invite links.
+ *
+ * Admin magic links created via admin.auth.admin.generateLink() use the OTP
+ * (implicit) flow: Supabase redirects back with #access_token=… in the URL
+ * hash rather than a ?code= query param.  Hash fragments are never sent to the
+ * server, so a server-side route handler can't process them.  This client
+ * component runs in the browser, lets @supabase/ssr detect the hash and set
+ * the session cookie, then calls a server action to finish account setup.
+ */
+export function PortalAuthCallbackClient({ tenantSlug }: { tenantSlug: string }) {
+  const router = useRouter();
+  const handled = useRef(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(async (event, session) => {
+      if (handled.current) return;
+
+      if (event === "SIGNED_IN" && session) {
+        handled.current = true;
+        const result = await finalizePortalSessionAction(tenantSlug);
+        if (result?.error === "not_invited") {
+          router.replace(`/portal/${tenantSlug}/login?error=not_invited`);
+        } else if (result?.error) {
+          router.replace(`/portal/${tenantSlug}/login?error=auth_callback_error`);
+        } else {
+          router.replace(`/portal/${tenantSlug}`);
+        }
+      } else if (event === "INITIAL_SESSION") {
+        if (session) {
+          // Returning user who somehow landed on this page while already signed in
+          handled.current = true;
+          router.replace(`/portal/${tenantSlug}`);
+        } else if (!window.location.hash.includes("access_token")) {
+          // No hash tokens and no session — nothing will arrive; bail out
+          handled.current = true;
+          router.replace(`/portal/${tenantSlug}/login?error=auth_callback_error`);
+        }
+        // If there ARE hash tokens, stay and wait for SIGNED_IN
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [tenantSlug, router]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <p className="text-sm text-muted-foreground">Signing you in…</p>
+    </div>
+  );
+}

--- a/components/portal/PortalCreateTaskDialog.tsx
+++ b/components/portal/PortalCreateTaskDialog.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useActionState, useEffect, useRef } from "react";
+import { useFormStatus } from "react-dom";
+import { createPortalTaskAction } from "@/app/actions/portal";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending} className="w-full">
+      {pending ? "Submitting…" : "Submit request"}
+    </Button>
+  );
+}
+
+export function PortalCreateTaskDialog({ tenantSlug }: { tenantSlug: string }) {
+  const action = createPortalTaskAction.bind(null, tenantSlug);
+  const [state, formAction] = useActionState(action, null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // Reset form on successful submission (redirect handles navigation,
+  // but reset here in case the redirect is slow)
+  useEffect(() => {
+    if (!state?.error) formRef.current?.reset();
+  }, [state]);
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="default">
+          New request
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Submit a new request</DialogTitle>
+        </DialogHeader>
+        <form ref={formRef} action={formAction} className="space-y-4 pt-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="title">What do you need help with?</Label>
+            <Input
+              id="title"
+              name="title"
+              placeholder="e.g. Update homepage copy"
+              autoFocus
+              required
+            />
+          </div>
+          {state?.error && (
+            <p className="text-sm text-destructive">{state.error}</p>
+          )}
+          <SubmitButton />
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -19,11 +19,13 @@ function isAdminRoute(pathname: string): boolean {
 }
 
 function isPortalProtectedRoute(pathname: string): boolean {
-  // Portal routes except the login page itself
+  // Portal routes except the login page and the auth-callback page
+  // (auth-callback must be reachable before the session is established)
   return (
     pathname.startsWith("/portal/") &&
     !pathname.endsWith("/login") &&
-    !pathname.includes("/login?")
+    !pathname.includes("/login?") &&
+    !pathname.endsWith("/auth-callback")
   );
 }
 

--- a/supabase/migrations/20260303000012_portal_tasks_invoices.sql
+++ b/supabase/migrations/20260303000012_portal_tasks_invoices.sql
@@ -1,0 +1,36 @@
+-- ── Portal: client task creation ─────────────────────────────────────────────
+-- Allows portal clients to submit new task requests.
+CREATE POLICY "client_tasks_insert" ON tasks
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    auth_role() = 'client'
+    AND tenant_id = auth_tenant_id()
+    AND client_id IN (
+      SELECT client_id FROM client_portal_access WHERE user_id = auth.uid()
+    )
+  );
+
+-- ── Portal: client invoice visibility ────────────────────────────────────────
+-- Clients can see invoices for their account that have been sent/viewed/paid.
+-- Draft invoices are intentionally excluded.
+CREATE POLICY "client_invoices_select" ON invoices
+  FOR SELECT TO authenticated
+  USING (
+    auth_role() = 'client'
+    AND client_id IN (
+      SELECT client_id FROM client_portal_access WHERE user_id = auth.uid()
+    )
+    AND status IN ('sent', 'viewed', 'paid')
+  );
+
+CREATE POLICY "client_invoice_line_items_select" ON invoice_line_items
+  FOR SELECT TO authenticated
+  USING (
+    auth_role() = 'client'
+    AND invoice_id IN (
+      SELECT i.id FROM invoices i
+      INNER JOIN client_portal_access cpa ON cpa.client_id = i.client_id
+      WHERE cpa.user_id = auth.uid()
+        AND i.status IN ('sent', 'viewed', 'paid')
+    )
+  );


### PR DESCRIPTION
## Summary

- **Task requests**: Clients can now submit new task requests directly from the portal via a "New request" dialog. The task is created with their `client_id` automatically; the admin handles priority, due date, etc. Backed by a new `client_tasks_insert` RLS policy.
- **Invoices**: New `/portal/[slug]/invoices` page shows all sent/viewed/paid invoices with status badge and outstanding balance. Viewing the page auto-transitions "sent" invoices to "viewed". New RLS SELECT policies for `invoices` and `invoice_line_items` (drafts excluded). Portal header now has Tasks | Invoices nav.
- **Auth-callback fix**: Admin-generated magic links use the OTP/implicit flow — Supabase redirects with `#access_token` in the URL hash, which the existing `/auth/callback` route handler (PKCE only) couldn't read, causing "user cannot be authenticated". New `/portal/[slug]/auth-callback` client component handles hash-fragment tokens via `@supabase/ssr`, then calls `finalizePortalSessionAction` to complete first-time account setup.

## Migration

`20260303000012_portal_tasks_invoices.sql` — three new RLS policies:
- `client_tasks_insert` on `tasks`
- `client_invoices_select` on `invoices`
- `client_invoice_line_items_select` on `invoice_line_items`

## Test plan

- [ ] Admin sends portal invite → client clicks email link → lands on portal (not error page)
- [ ] First-time client: profile + portal_access + app_metadata created correctly
- [ ] Returning client: redirect straight to portal without re-running setup
- [ ] Portal dashboard shows "New request" button; submitting creates task and redirects to it
- [ ] Portal nav shows Tasks and Invoices links
- [ ] Invoices page lists sent/viewed/paid invoices; draft invoices hidden
- [ ] Opening invoices page flips "sent" → "viewed" on the admin side
- [ ] Self-initiated magic link from portal login form still works (PKCE path unchanged)
- [ ] Impersonating admin does not see "New request" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)