### PR TITLE
fix: portal accepted status not updating + Portal Users page

### DIFF
--- a/app/(admin)/portal-users/page.tsx
+++ b/app/(admin)/portal-users/page.tsx
@@ -1,0 +1,178 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { TopBar } from "@/components/layout/TopBar";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { CheckCircle2, Clock, ChevronRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+function formatDate(d: string | null) {
+  if (!d) return null;
+  return new Date(d).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+async function PortalUsersTable() {
+  const supabase = await createClient();
+
+  const { data: rows, error } = await supabase
+    .from("client_portal_access")
+    .select("client_id, accepted_at, invited_at, last_seen_at, user_id")
+    .order("invited_at", { ascending: false });
+
+  if (error) {
+    return (
+      <p className="text-sm text-destructive">
+        Failed to load portal users: {error.message}
+      </p>
+    );
+  }
+
+  if (!rows || rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-border py-16 text-center">
+        <p className="text-sm font-medium">No portal users yet.</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Grant portal access from a client&apos;s detail page.
+        </p>
+      </div>
+    );
+  }
+
+  // Fetch client names + emails in bulk
+  const clientIds = rows.map((r) => r.client_id);
+  const { data: clients } = await supabase
+    .from("clients")
+    .select("id, name, email, color")
+    .in("id", clientIds);
+  const clientMap = new Map(
+    (clients ?? []).map((c) => [c.id, c])
+  );
+
+  // Fetch auth emails for accepted users (user_id is set)
+  const userIds = rows
+    .map((r) => r.user_id as string | null)
+    .filter((id): id is string => !!id);
+
+  const admin = createAdminClient();
+  const portalEmailMap = new Map<string, string>();
+  await Promise.all(
+    userIds.map(async (uid) => {
+      const { data } = await admin.auth.admin.getUserById(uid);
+      if (data?.user?.email) portalEmailMap.set(uid, data.user.email);
+    })
+  );
+
+  return (
+    <div className="rounded-md border border-border overflow-x-auto">
+      <table className="w-full min-w-[640px] text-sm">
+        <thead>
+          <tr className="border-b border-border bg-muted/40">
+            <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
+              Client
+            </th>
+            <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
+              Portal email
+            </th>
+            <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
+              Status
+            </th>
+            <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
+              Invited
+            </th>
+            <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
+              First login
+            </th>
+            <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
+              Last seen
+            </th>
+            <th className="w-8" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => {
+            const client = clientMap.get(row.client_id);
+            const portalEmail = row.user_id
+              ? (portalEmailMap.get(row.user_id as string) ?? null)
+              : null;
+            const accepted = !!(row.accepted_at);
+
+            return (
+              <tr
+                key={row.client_id}
+                className="group hover:bg-muted/30 transition-colors"
+              >
+                <td className="px-4 py-3">
+                  <Link
+                    href={`/clients/${row.client_id}`}
+                    className="flex items-center gap-2.5"
+                  >
+                    <span
+                      className="h-2 w-2 shrink-0 rounded-full"
+                      style={{
+                        backgroundColor: client?.color ?? "#0969da",
+                      }}
+                    />
+                    <span className="font-medium text-foreground hover:underline">
+                      {client?.name ?? "Unknown"}
+                    </span>
+                  </Link>
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {portalEmail ?? client?.email ?? "—"}
+                </td>
+                <td className="px-4 py-3">
+                  {accepted ? (
+                    <Badge
+                      variant="outline"
+                      className="gap-1 text-xs text-emerald-600 border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-400"
+                    >
+                      <CheckCircle2 className="h-3 w-3" />
+                      Active
+                    </Badge>
+                  ) : (
+                    <Badge
+                      variant="outline"
+                      className="gap-1 text-xs text-amber-600 border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-400"
+                    >
+                      <Clock className="h-3 w-3" />
+                      Pending
+                    </Badge>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-muted-foreground tabular-nums">
+                  {formatDate((row as { invited_at?: string | null }).invited_at ?? null) ?? "—"}
+                </td>
+                <td className="px-4 py-3 text-muted-foreground tabular-nums">
+                  {formatDate(row.accepted_at) ?? "—"}
+                </td>
+                <td className="px-4 py-3 text-muted-foreground tabular-nums">
+                  {formatDate((row as { last_seen_at?: string | null }).last_seen_at ?? null) ?? "Never"}
+                </td>
+                <td className="pr-3">
+                  <Link href={`/clients/${row.client_id}`}>
+                    <ChevronRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                  </Link>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default async function PortalUsersPage() {
+  return (
+    <>
+      <TopBar title="Portal Users" description="Clients with access to the client portal" />
+      <PageContainer>
+        <PortalUsersTable />
+      </PageContainer>
+    </>
+  );
+}

--- a/app/actions/portal.ts
+++ b/app/actions/portal.ts
@@ -164,7 +164,23 @@ export async function finalizePortalSessionAction(
       await supabase.auth.signOut();
       return { error: "Unauthorized." };
     }
-    return {}; // Returning client — nothing to set up
+    // Returning client — always refresh last_seen_at.
+    // Also patch accepted_at if it's somehow null (e.g. prior partial setup).
+    const now = new Date().toISOString();
+    const adminClient = createAdminClient();
+    const { data: accessRow } = await adminClient
+      .from("client_portal_access")
+      .select("accepted_at")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    await adminClient
+      .from("client_portal_access")
+      .update({
+        last_seen_at: now,
+        ...(accessRow && !accessRow.accepted_at ? { accepted_at: now } : {}),
+      })
+      .eq("user_id", user.id);
+    return {};
   }
 
   // First-time sign-in: set up the portal account
@@ -215,10 +231,11 @@ export async function finalizePortalSessionAction(
     .eq("tenant_id", tenant.id)
     .maybeSingle();
 
+  const now = new Date().toISOString();
   if (existingAccess) {
     await admin
       .from("client_portal_access")
-      .update({ user_id: user.id, accepted_at: new Date().toISOString() })
+      .update({ user_id: user.id, accepted_at: now, last_seen_at: now })
       .eq("client_id", client.id)
       .eq("tenant_id", tenant.id);
   } else {
@@ -226,7 +243,8 @@ export async function finalizePortalSessionAction(
       tenant_id: tenant.id,
       client_id: client.id,
       user_id: user.id,
-      accepted_at: new Date().toISOString(),
+      accepted_at: now,
+      last_seen_at: now,
     });
   }
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Settings,
   Zap,
   Mail,
+  Globe,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -22,6 +23,7 @@ const navItems = [
   { href: "/tasks", label: "Tasks", icon: CheckSquare },
   { href: "/time", label: "Time", icon: Clock },
   { href: "/invoices", label: "Invoices", icon: FileText },
+  { href: "/portal-users", label: "Portal Users", icon: Globe },
   { href: "/reports", label: "Reports", icon: BarChart2 },
   { href: "/settings", label: "Settings", icon: Settings },
   { href: "/email-log", label: "Email Log", icon: Mail },

--- a/components/portal/PortalAuthCallbackClient.tsx
+++ b/components/portal/PortalAuthCallbackClient.tsx
@@ -31,13 +31,23 @@ export function PortalAuthCallbackClient({ tenantSlug }: { tenantSlug: string })
     const refreshToken = params.get("refresh_token");
 
     if (!accessToken || !refreshToken) {
-      // No hash tokens — check for an existing session (returning user who
-      // somehow landed here, or a stale/bad link).
-      supabase.auth.getSession().then(({ data: { session } }) => {
+      // No hash tokens — check for an existing session. This covers two cases:
+      // 1. Returning user who already has a session (e.g. navigated back).
+      // 2. PKCE flow where @supabase/ssr exchanged ?code= automatically.
+      // In both cases we still call finalizePortalSessionAction so that
+      // accepted_at / last_seen_at are kept up-to-date.
+      supabase.auth.getSession().then(async ({ data: { session } }) => {
         if (handled.current) return;
         handled.current = true;
         if (session) {
-          router.replace(`/portal/${tenantSlug}`);
+          const result = await finalizePortalSessionAction(tenantSlug);
+          if (result?.error === "not_invited") {
+            router.replace(`/portal/${tenantSlug}/login?error=not_invited`);
+          } else if (result?.error) {
+            router.replace(`/portal/${tenantSlug}/login?error=auth_callback_error`);
+          } else {
+            router.replace(`/portal/${tenantSlug}`);
+          }
         } else {
           router.replace(`/portal/${tenantSlug}/login?error=auth_callback_error`);
         }


### PR DESCRIPTION
## Summary

- **Bug fix**: Invited clients who logged in to the portal were never showing as "Active" — `accepted_at` and `last_seen_at` were not being written reliably
- **Bug fix**: `PortalAuthCallbackClient` skipped `finalizePortalSessionAction` when no URL hash tokens were present (PKCE flow / returning user), so the DB was never updated
- **Feature**: New `/portal-users` admin page listing all invited/accepted portal users with status, dates, and links to client detail pages; added to sidebar nav

## Root causes

1. **`PortalAuthCallbackClient`** — The "no hash tokens but session exists" path (hit when the Supabase project uses PKCE flow, or when a returning user lands on the callback URL) redirected straight to the portal without calling `finalizePortalSessionAction`. This meant `accepted_at` was never set for those logins.

2. **`finalizePortalSessionAction`** — For returning users (already have a profile), the action returned early without touching `accepted_at` or `last_seen_at`. If `accepted_at` was null due to a prior partial-setup or the PKCE path, it would stay null permanently.

## Changes

| File | Change |
|------|--------|
| `components/portal/PortalAuthCallbackClient.tsx` | Always call `finalizePortalSessionAction` when a session is found, even without hash tokens |
| `app/actions/portal.ts` | Returning users: refresh `last_seen_at` every login, patch `accepted_at` if null. First-time users: set `last_seen_at` alongside `accepted_at` |
| `app/(admin)/portal-users/page.tsx` | New page — table of all portal invites with Active/Pending status badges |
| `components/layout/Sidebar.tsx` | Add "Portal Users" nav item with Globe icon |

## Test plan

- [ ] Invite a client via "Grant access" on the client detail page
- [ ] Client clicks magic link and signs in → client detail page shows **Active** (green) status
- [ ] `/portal-users` nav item appears in sidebar and loads the table
- [ ] Accepted clients show **Active** badge; pending invites show **Pending** badge
- [ ] Last seen date updates on subsequent logins

🤖 Generated with [Claude Code](https://claude.com/claude-code)