### PR TITLE
fix: remove last_seen_at references until migration is applied

### DIFF
--- a/app/(admin)/clients/[clientId]/page.tsx
+++ b/app/(admin)/clients/[clientId]/page.tsx
@@ -36,7 +36,7 @@ export default async function ClientDetailPage({
     supabase.from("clients").select("*").eq("id", clientId).single(),
     supabase
       .from("client_portal_access")
-      .select("accepted_at, invited_at, last_seen_at, user_id")
+      .select("accepted_at, invited_at, user_id")
       .eq("client_id", clientId)
       .maybeSingle(),
     supabase
@@ -149,7 +149,7 @@ export default async function ClientDetailPage({
               ? {
                   accepted_at: portalAccess.accepted_at ?? null,
                   invited_at: (portalAccess as { invited_at?: string | null }).invited_at ?? null,
-                  last_seen_at: (portalAccess as { last_seen_at?: string | null }).last_seen_at ?? null,
+                  last_seen_at: null,
                 }
               : null
           }

--- a/app/(admin)/portal-users/page.tsx
+++ b/app/(admin)/portal-users/page.tsx
@@ -20,7 +20,7 @@ async function PortalUsersTable() {
 
   const { data: rows, error } = await supabase
     .from("client_portal_access")
-    .select("client_id, accepted_at, invited_at, last_seen_at, user_id")
+    .select("client_id, accepted_at, invited_at, user_id")
     .order("invited_at", { ascending: false });
 
   if (error) {
@@ -86,9 +86,6 @@ async function PortalUsersTable() {
             <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
               First login
             </th>
-            <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
-              Last seen
-            </th>
             <th className="w-8" />
           </tr>
         </thead>
@@ -148,9 +145,6 @@ async function PortalUsersTable() {
                 </td>
                 <td className="px-4 py-3 text-muted-foreground tabular-nums">
                   {formatDate(row.accepted_at) ?? "—"}
-                </td>
-                <td className="px-4 py-3 text-muted-foreground tabular-nums">
-                  {formatDate((row as { last_seen_at?: string | null }).last_seen_at ?? null) ?? "Never"}
                 </td>
                 <td className="pr-3">
                   <Link href={`/clients/${row.client_id}`}>

--- a/app/actions/portal.ts
+++ b/app/actions/portal.ts
@@ -164,8 +164,7 @@ export async function finalizePortalSessionAction(
       await supabase.auth.signOut();
       return { error: "Unauthorized." };
     }
-    // Returning client — always refresh last_seen_at.
-    // Also patch accepted_at if it's somehow null (e.g. prior partial setup).
+    // Returning client — patch accepted_at if somehow null (e.g. prior partial setup).
     const now = new Date().toISOString();
     const adminClient = createAdminClient();
     const { data: accessRow } = await adminClient
@@ -173,13 +172,12 @@ export async function finalizePortalSessionAction(
       .select("accepted_at")
       .eq("user_id", user.id)
       .maybeSingle();
-    await adminClient
-      .from("client_portal_access")
-      .update({
-        last_seen_at: now,
-        ...(accessRow && !accessRow.accepted_at ? { accepted_at: now } : {}),
-      })
-      .eq("user_id", user.id);
+    if (accessRow && !accessRow.accepted_at) {
+      await adminClient
+        .from("client_portal_access")
+        .update({ accepted_at: now })
+        .eq("user_id", user.id);
+    }
     return {};
   }
 
@@ -235,7 +233,7 @@ export async function finalizePortalSessionAction(
   if (existingAccess) {
     await admin
       .from("client_portal_access")
-      .update({ user_id: user.id, accepted_at: now, last_seen_at: now })
+      .update({ user_id: user.id, accepted_at: now })
       .eq("client_id", client.id)
       .eq("tenant_id", tenant.id);
   } else {
@@ -244,7 +242,6 @@ export async function finalizePortalSessionAction(
       client_id: client.id,
       user_id: user.id,
       accepted_at: now,
-      last_seen_at: now,
     });
   }
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -112,10 +112,11 @@ export async function GET(request: NextRequest) {
       .eq("tenant_id", tenant.id)
       .maybeSingle();
 
+    const now = new Date().toISOString();
     if (existingAccess) {
       await admin
         .from("client_portal_access")
-        .update({ user_id: user.id, accepted_at: new Date().toISOString() })
+        .update({ user_id: user.id, accepted_at: now })
         .eq("client_id", client.id)
         .eq("tenant_id", tenant.id);
     } else {
@@ -123,7 +124,7 @@ export async function GET(request: NextRequest) {
         tenant_id: tenant.id,
         client_id: client.id,
         user_id: user.id,
-        accepted_at: new Date().toISOString(),
+        accepted_at: now,
       });
     }
 


### PR DESCRIPTION
## Summary

- The `last_seen_at` column (added in migration `20260303000009_portal_last_seen.sql`) was not applied to the production database
- Any query that explicitly selects `last_seen_at` fails with a PostgREST error — including the client detail page's `client_portal_access` query, which was failing **silently** (error not destructured), causing `portalAccess` to always be `null` and always showing "No portal access"
- This was the root cause behind the "never shows accepted" bug

## Changes

- Remove `last_seen_at` from all `select()` calls on `client_portal_access`
- Remove `last_seen_at` from `insert`/`update` calls in `finalizePortalSessionAction` and `auth/callback`
- Drop the "Last seen" column from the Portal Users table for now

## To re-enable Last seen

Run the pending migration against the production Supabase project:
\`\`\`
supabase db push
\`\`\`
Migration `20260303000009_portal_last_seen.sql` already exists and uses `ADD COLUMN IF NOT EXISTS`, so it's safe to apply.

## Test plan

- [ ] Client detail page shows "Active" status after client logs in (no longer fails silently)
- [ ] `/portal-users` page loads without error
- [ ] Invited clients show Pending; accepted clients show Active

🤖 Generated with [Claude Code](https://claude.com/claude-code)