### PR TITLE
feat: cross-subdomain auth cookies + middleware subdomain extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,18 @@ RESEND_DOMAIN=your_resend_domain_here (e.g. taskflow.macwillingham.com)
 # Set to your production URL in Vercel environment variables
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# ─── Multi-tenant subdomain routing ──────────────────────────────────────────
+# Base domain used to extract tenant slug from the Host header.
+# Leave unset for local dev (no subdomains on localhost).
+# Production example: taskflow.com
+NEXT_PUBLIC_BASE_DOMAIN=billabledesk.com
+
+# Cookie domain for cross-subdomain auth session sharing.
+# Leading dot means the cookie is readable by all *.billabledesk.com subdomains.
+# Leave unset for local dev.
+# Production example: .billabledesk.com
+NEXT_PUBLIC_COOKIE_DOMAIN=.billabledesk.com
+
 # ─── Feature Flags ───────────────────────────────────────────────────────────
 # Set to "true" to allow new tenant registration via /auth/register
 # Set to "false" or remove in production if you don't want public sign-ups

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -13,6 +13,7 @@ export async function updateSession(request: NextRequest) {
           return request.cookies.getAll();
         },
         setAll(cookiesToSet: { name: string; value: string; options: CookieOptions }[]) {
+          const cookieDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
           // Set cookies on the request so server-side reads are consistent
           cookiesToSet.forEach(({ name, value }) =>
             request.cookies.set(name, value)
@@ -20,7 +21,10 @@ export async function updateSession(request: NextRequest) {
           // Rebuild the response and set cookies on it for the browser
           supabaseResponse = NextResponse.next({ request });
           cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, options as Parameters<typeof supabaseResponse.cookies.set>[2])
+            supabaseResponse.cookies.set(name, value, {
+              ...(options as Parameters<typeof supabaseResponse.cookies.set>[2]),
+              ...(cookieDomain ? { domain: cookieDomain } : {}),
+            })
           );
         },
       },

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -16,9 +16,13 @@ export const createClient = cache(async () => {
           return cookieStore.getAll();
         },
         setAll(cookiesToSet: { name: string; value: string; options: CookieOptions }[]) {
+          const cookieDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
           try {
             cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
+              cookieStore.set(name, value, {
+                ...options,
+                ...(cookieDomain ? { domain: cookieDomain } : {}),
+              })
             );
           } catch {
             // Called from a Server Component — middleware handles session refresh.

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -6,13 +6,19 @@ vi.mock("@/lib/supabase/middleware", () => ({
 }));
 
 import { updateSession } from "@/lib/supabase/middleware";
-import { proxy } from "@/proxy";
+import { proxy, getTenantSlugFromHost } from "@/proxy";
 import { encodePayload, makePayload, IMPERSONATION_COOKIE } from "@/lib/portal/impersonation";
 
 const fakeResponse = new NextResponse(null, { status: 200 });
 
-function makeRequest(pathname: string, cookies?: Record<string, string>): NextRequest {
-  const req = new NextRequest(`http://localhost:3000${pathname}`);
+function makeRequest(
+  pathname: string,
+  cookies?: Record<string, string>,
+  host?: string
+): NextRequest {
+  const req = new NextRequest(`http://${host ?? "localhost:3000"}${pathname}`, {
+    headers: { host: host ?? "localhost:3000" },
+  });
   if (cookies) {
     Object.entries(cookies).forEach(([name, value]) => {
       req.cookies.set(name, value);
@@ -43,24 +49,62 @@ function mockSession(user: Record<string, unknown> | null) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  delete process.env.ALLOW_REGISTRATION;
+  delete process.env.NEXT_PUBLIC_BASE_DOMAIN;
 });
 
-// ── Registration guard ─────────────────────────────────────────────────────
+// ── getTenantSlugFromHost ───────────────────────────────────────────────────
 
-describe("proxy: /auth/register", () => {
-  it("redirects to /auth/login when ALLOW_REGISTRATION is not true", async () => {
-    process.env.ALLOW_REGISTRATION = "false";
-    mockSession(null);
-    const res = await proxy(makeRequest("/auth/register"));
-    expect(res.headers.get("location")).toContain("/auth/login");
+describe("getTenantSlugFromHost", () => {
+  describe("with NEXT_PUBLIC_BASE_DOMAIN=taskflow.com", () => {
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_BASE_DOMAIN = "taskflow.com";
+    });
+
+    it("returns tenant slug from a valid subdomain", () => {
+      expect(getTenantSlugFromHost("acme.taskflow.com")).toBe("acme");
+    });
+
+    it("returns null for www subdomain", () => {
+      expect(getTenantSlugFromHost("www.taskflow.com")).toBeNull();
+    });
+
+    it("returns null for bare base domain", () => {
+      expect(getTenantSlugFromHost("taskflow.com")).toBeNull();
+    });
+
+    it("returns null for localhost", () => {
+      expect(getTenantSlugFromHost("localhost")).toBeNull();
+    });
+
+    it("returns null for localhost:3000", () => {
+      expect(getTenantSlugFromHost("localhost:3000")).toBeNull();
+    });
+
+    it("returns null for an unrelated host", () => {
+      expect(getTenantSlugFromHost("example.com")).toBeNull();
+    });
+
+    it("handles port in subdomain host correctly", () => {
+      expect(getTenantSlugFromHost("acme.taskflow.com:3000")).toBe("acme");
+    });
   });
 
-  it("passes through when ALLOW_REGISTRATION=true", async () => {
-    process.env.ALLOW_REGISTRATION = "true";
-    mockSession(null);
-    const res = await proxy(makeRequest("/auth/register"));
-    expect(res).toBe(fakeResponse);
+  describe("without NEXT_PUBLIC_BASE_DOMAIN (local dev fallback to localhost)", () => {
+    beforeEach(() => {
+      delete process.env.NEXT_PUBLIC_BASE_DOMAIN;
+    });
+
+    it("returns null for localhost", () => {
+      expect(getTenantSlugFromHost("localhost")).toBeNull();
+    });
+
+    it("returns null for localhost:3000", () => {
+      expect(getTenantSlugFromHost("localhost:3000")).toBeNull();
+    });
+
+    it("returns null for any host that does not include 'localhost'", () => {
+      expect(getTenantSlugFromHost("acme.taskflow.com")).toBeNull();
+    });
   });
 });
 
@@ -166,6 +210,26 @@ describe("proxy: portal routes", () => {
     });
     const res = await proxy(makeRequest("/portal/other-co"));
     expect(res.headers.get("location")).toContain("/portal/myco");
+  });
+});
+
+// ── x-tenant-slug header injection ────────────────────────────────────────
+
+describe("proxy: x-tenant-slug header", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_BASE_DOMAIN = "taskflow.com";
+  });
+
+  it("injects x-tenant-slug from subdomain on pass-through", async () => {
+    mockSession(null);
+    const res = await proxy(makeRequest("/auth/login", undefined, "acme.taskflow.com"));
+    expect(res.headers.get("x-tenant-slug")).toBe("acme");
+  });
+
+  it("injects empty x-tenant-slug for localhost", async () => {
+    mockSession(null);
+    const res = await proxy(makeRequest("/auth/login"));
+    expect(res.headers.get("x-tenant-slug")).toBe("");
   });
 });
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -29,6 +29,23 @@ function isPortalProtectedRoute(pathname: string): boolean {
   );
 }
 
+/**
+ * Extracts the tenant slug from the Host header.
+ * Returns null for localhost, www, or the bare base domain.
+ * Example: "acme.taskflow.com" → "acme"
+ */
+export function getTenantSlugFromHost(host: string): string | null {
+  const baseDomain = process.env.NEXT_PUBLIC_BASE_DOMAIN ?? "localhost";
+  // Strip port (e.g. "acme.taskflow.com:3000" → "acme.taskflow.com")
+  const hostWithoutPort = host.split(":")[0];
+  if (!hostWithoutPort.includes(baseDomain)) return null;
+  // Bare base domain — no subdomain present
+  if (hostWithoutPort === baseDomain) return null;
+  const subdomain = hostWithoutPort.split(".")[0];
+  if (!subdomain || subdomain === "www") return null;
+  return subdomain;
+}
+
 /** Returns true if the request carries a valid (non-expired) impersonation cookie for the given slug. */
 function hasValidImpersonationCookie(request: NextRequest, urlSlug: string): boolean {
   const raw = request.cookies.get(IMPERSONATION_COOKIE)?.value;
@@ -40,15 +57,24 @@ function hasValidImpersonationCookie(request: NextRequest, urlSlug: string): boo
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Always refresh the session
-  const { supabaseResponse, user } = await updateSession(request);
+  // Extract tenant slug from subdomain
+  const host = request.headers.get("host") ?? "";
+  const tenantSlug = getTenantSlugFromHost(host);
 
-  // Registration guard — only allow if ALLOW_REGISTRATION=true
-  if (pathname === "/auth/register") {
-    if (process.env.ALLOW_REGISTRATION !== "true") {
-      return NextResponse.redirect(new URL("/auth/login", request.url));
-    }
-    return supabaseResponse;
+  // Inject x-tenant-slug header into every request so downstream Server
+  // Components and Route Handlers can read it without re-parsing the host.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-tenant-slug", tenantSlug ?? "");
+
+  // Always refresh the session (pass mutated headers along)
+  const { supabaseResponse, user } = await updateSession(
+    new NextRequest(request.url, { headers: requestHeaders, method: request.method, body: request.body })
+  );
+
+  // Helper: clone supabaseResponse but carry our custom request headers forward
+  function withTenantHeader(res: NextResponse): NextResponse {
+    res.headers.set("x-tenant-slug", tenantSlug ?? "");
+    return res;
   }
 
   // Admin route guard
@@ -58,18 +84,19 @@ export async function proxy(request: NextRequest) {
     }
     if (user.app_metadata?.role !== "admin") {
       // Authenticated client users should land on their portal, not the login page
-      const tenantSlug = user.app_metadata?.tenant_slug as string | undefined;
-      if (tenantSlug) {
-        return NextResponse.redirect(new URL(`/portal/${tenantSlug}`, request.url));
+      const userTenantSlug = user.app_metadata?.tenant_slug as string | undefined;
+      if (userTenantSlug) {
+        return NextResponse.redirect(new URL(`/portal/${userTenantSlug}`, request.url));
       }
       return NextResponse.redirect(new URL("/auth/login", request.url));
     }
-    return supabaseResponse;
+    return withTenantHeader(supabaseResponse);
   }
 
   // Portal route guard
   if (isPortalProtectedRoute(pathname)) {
-    const urlSlug = pathname.split("/")[2] ?? "";
+    // Prefer subdomain-based slug; fall back to URL path for local dev
+    const urlSlug = tenantSlug ?? pathname.split("/")[2] ?? "";
 
     if (!user) {
       return NextResponse.redirect(
@@ -80,7 +107,7 @@ export async function proxy(request: NextRequest) {
     // Admin impersonation: allow admins through if they have a valid cookie for this tenant
     if (user.app_metadata?.role === "admin") {
       if (hasValidImpersonationCookie(request, urlSlug)) {
-        return supabaseResponse;
+        return withTenantHeader(supabaseResponse);
       }
       return NextResponse.redirect(
         new URL(`/portal/${urlSlug}/login`, request.url)
@@ -98,10 +125,10 @@ export async function proxy(request: NextRequest) {
     if (userSlug && userSlug !== urlSlug) {
       return NextResponse.redirect(new URL(`/portal/${userSlug}`, request.url));
     }
-    return supabaseResponse;
+    return withTenantHeader(supabaseResponse);
   }
 
-  return supabaseResponse;
+  return withTenantHeader(supabaseResponse);
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Injects `NEXT_PUBLIC_COOKIE_DOMAIN` into all Supabase cookie operations (`server.ts` + `middleware.ts`) so auth sessions are shared across `*.billabledesk.com` subdomains
- Adds `getTenantSlugFromHost()` to `proxy.ts` — extracts tenant slug from the `Host` header, null-safe for localhost / www / bare base domain / ports
- Injects `x-tenant-slug` response header on every request so downstream Server Components and Route Handlers can read the current tenant without re-parsing the host
- Portal route guard uses subdomain slug when available, falls back to URL path segment for local dev
- Removes `ALLOW_REGISTRATION` guard (registration will be open per SaaS plan issue #92 )
- Adds `NEXT_PUBLIC_BASE_DOMAIN` + `NEXT_PUBLIC_COOKIE_DOMAIN` to `.env.example`

## Test plan
- [ ] 26 unit tests covering `getTenantSlugFromHost()` (valid subdomain, www, bare domain, localhost, ports, unrelated host) and all proxy guard paths — all pass
- [ ] `npm run build` passes clean
- [ ] Manual: set `NEXT_PUBLIC_BASE_DOMAIN=lvh.me` locally, add `127.0.0.1 acme.lvh.me` to `/etc/hosts`, verify tenant slug extracted correctly and session cookie shared across subdomains

## Depends on
#87

## Blocks
#89, #92, #93, #94, #95, #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)