### PR TITLE
feat: subdomain-aware auth callbacks + open registration

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -14,10 +14,6 @@ function generateSlug(businessName: string): string {
 }
 
 export async function POST(request: NextRequest) {
-  if (process.env.ALLOW_REGISTRATION !== "true") {
-    return NextResponse.json({ error: "Registration is disabled." }, { status: 403 });
-  }
-
   const { businessName, email, password } = await request.json();
 
   if (!businessName || !email || !password) {
@@ -93,7 +89,7 @@ export async function POST(request: NextRequest) {
 
     if (metaError) throw new Error(metaError.message);
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, slug });
   } catch (err) {
     // Clean up the auth user if anything downstream failed
     await admin.auth.admin.deleteUser(userId);

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { getTenantSlugFromHost } from "@/proxy";
 
 function generateSlug(name: string): string {
   return (
@@ -14,10 +15,15 @@ function generateSlug(name: string): string {
   );
 }
 
+function tenantUrl(slug: string, path: string): string {
+  const base = process.env.NEXT_PUBLIC_BASE_DOMAIN ?? "localhost";
+  if (base === "localhost") return `http://localhost:3000${path}`;
+  return `https://${slug}.${base}${path}`;
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/dashboard";
 
   if (!code) {
     return NextResponse.redirect(`${origin}/auth/login?error=auth_callback_error`);
@@ -38,6 +44,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${origin}/auth/login?error=auth_callback_error`);
   }
 
+  // Detect portal vs admin callback via subdomain
+  const host = request.headers.get("host") ?? "";
+  const subdomain = getTenantSlugFromHost(host);
+  const isPortalCallback = !!subdomain;
+
   // Check whether this user already has a profile (returning user)
   const { data: existingProfile } = await supabase
     .from("profiles")
@@ -46,23 +57,21 @@ export async function GET(request: NextRequest) {
     .single();
 
   if (existingProfile) {
-    // Returning user — redirect based on role
+    const tenantSlug = user.app_metadata?.tenant_slug as string | undefined;
     if (existingProfile.role === "client") {
-      const tenantSlug = user.app_metadata?.tenant_slug as string | undefined;
-      if (tenantSlug) return NextResponse.redirect(`${origin}/portal/${tenantSlug}`);
+      if (tenantSlug) return NextResponse.redirect(tenantUrl(tenantSlug, "/portal"));
       return NextResponse.redirect(`${origin}/auth/login?error=auth_callback_error`);
     }
-    return NextResponse.redirect(`${origin}${next}`);
+    // Admin returning user
+    if (tenantSlug) return NextResponse.redirect(tenantUrl(tenantSlug, "/dashboard"));
+    return NextResponse.redirect(`${origin}/dashboard`);
   }
 
   // ── Portal first-time sign-in (OTP magic link OR Google OAuth) ──────────
-  // No profile + next is a portal URL.
+  // No profile + callback arrived on a tenant subdomain.
   // Match the user's email to an existing clients record to authorize access.
-  // If the admin already granted access (pending row exists), update it.
-  // Otherwise insert a new access row (backwards-compat for Google OAuth
-  // users who weren't pre-invited).
-  if (next.startsWith("/portal/")) {
-    const portalSlug = next.split("/")[2];
+  if (isPortalCallback) {
+    const portalSlug = subdomain;
     const admin = createAdminClient();
 
     const { data: tenant } = await admin
@@ -73,7 +82,7 @@ export async function GET(request: NextRequest) {
     if (!tenant) {
       await supabase.auth.signOut();
       return NextResponse.redirect(
-        `${origin}/portal/${portalSlug}/login?error=auth_callback_error`
+        `${origin}/portal/login?error=auth_callback_error`
       );
     }
 
@@ -86,7 +95,7 @@ export async function GET(request: NextRequest) {
     if (!client) {
       await supabase.auth.signOut();
       return NextResponse.redirect(
-        `${origin}/portal/${portalSlug}/login?error=not_invited`
+        `${origin}/portal/login?error=not_invited`
       );
     }
 
@@ -134,18 +143,12 @@ export async function GET(request: NextRequest) {
         tenant_slug: tenant.slug,
       },
     });
-    return NextResponse.redirect(`${origin}/portal/${tenant.slug}`);
+    return NextResponse.redirect(tenantUrl(tenant.slug, "/portal"));
   }
 
-  // ── First-time OAuth sign-in ──────────────────────────────────────────────
-  // No profile means this is a brand-new user (e.g. Google OAuth first login).
-  // Create a tenant + profile + settings, then set app_metadata.
-
-  if (process.env.ALLOW_REGISTRATION !== "true") {
-    await supabase.auth.signOut();
-    return NextResponse.redirect(`${origin}/auth/login?error=registration_disabled`);
-  }
-
+  // ── First-time admin OAuth sign-in ───────────────────────────────────────
+  // No profile + callback on root domain → new admin user via Google OAuth.
+  // Create a tenant + profile + settings, then redirect to tenant subdomain.
   const admin = createAdminClient();
   const displayName =
     user.user_metadata?.full_name ??
@@ -191,5 +194,5 @@ export async function GET(request: NextRequest) {
     app_metadata: { role: "admin", tenant_id: tenantId, tenant_slug: slug },
   });
 
-  return NextResponse.redirect(`${origin}${next}`);
+  return NextResponse.redirect(tenantUrl(slug, "/dashboard"));
 }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -14,8 +14,6 @@ function errorMessage(code: string | null): string | null {
   switch (code) {
     case "auth_callback_error":
       return "Authentication failed. Please try again.";
-    case "registration_disabled":
-      return "Account registration is not enabled.";
     default:
       return null;
   }
@@ -89,7 +87,7 @@ function LoginForm() {
     setLoading(true);
 
     const supabase = createClient();
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
 
     if (error) {
       setError(error.message);
@@ -97,8 +95,14 @@ function LoginForm() {
       return;
     }
 
-    router.push("/dashboard");
-    router.refresh();
+    const tenantSlug = data.user?.app_metadata?.tenant_slug as string | undefined;
+    const base = process.env.NEXT_PUBLIC_BASE_DOMAIN;
+    if (tenantSlug && base && base !== "localhost") {
+      window.location.href = `https://${tenantSlug}.${base}/dashboard`;
+    } else {
+      router.push("/dashboard");
+      router.refresh();
+    }
   }
 
   async function handleGoogleSignIn() {
@@ -269,14 +273,12 @@ export default function LoginPage() {
           <LoginForm />
         </Suspense>
 
-        {process.env.NEXT_PUBLIC_ALLOW_REGISTRATION === "true" && (
-          <p className="text-center text-sm text-muted-foreground">
-            Don&apos;t have an account?{" "}
-            <Link href="/auth/register" className="text-foreground hover:underline">
-              Create one
-            </Link>
-          </p>
-        )}
+        <p className="text-center text-sm text-muted-foreground">
+          Don&apos;t have an account?{" "}
+          <Link href="/auth/register" className="text-foreground hover:underline">
+            Create one
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -11,7 +10,6 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Zap } from "lucide-react";
 
 export default function RegisterPage() {
-  const router = useRouter();
   const [businessName, setBusinessName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -58,8 +56,12 @@ export default function RegisterPage() {
       return;
     }
 
-    router.push("/dashboard");
-    router.refresh();
+    const base = process.env.NEXT_PUBLIC_BASE_DOMAIN;
+    if (base && base !== "localhost") {
+      window.location.href = `https://${data.slug}.${base}/dashboard`;
+    } else {
+      window.location.href = `http://localhost:3000/dashboard`;
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary

- **`app/auth/callback/route.ts`**: Detect portal vs admin callback from the `Host` subdomain instead of `?next=` query param. Returning and first-time users are redirected to their tenant subdomain (`https://{slug}.{BASE_DOMAIN}/dashboard` or `/portal`). The `ALLOW_REGISTRATION` gate for first-time admin Google OAuth is removed.
- **`app/api/auth/register/route.ts`**: `ALLOW_REGISTRATION` env var guard removed; response now includes `slug` so the client can construct the cross-origin redirect.
- **`app/auth/register/page.tsx`**: After sign-in, does a hard `window.location.href` cross-origin redirect to `https://{slug}.{BASE_DOMAIN}/dashboard`.
- **`app/auth/login/page.tsx`**: After password sign-in, redirects to tenant subdomain; register link shown unconditionally; `registration_disabled` error case removed.

## Test plan

- [ ] New user registers → lands on `{slug}.taskflow.com/dashboard`
- [ ] Returning admin signs in with password at root domain → redirected to `{slug}.taskflow.com/dashboard`
- [ ] First-time admin Google OAuth → tenant created, redirected to `{slug}.taskflow.com/dashboard`
- [ ] Portal client clicks magic link (subdomain callback) → lands on `{slug}.taskflow.com/portal`
- [ ] Portal client uses Google OAuth (subdomain callback) → same result
- [ ] First-time portal OAuth client → profile + portal_access created, redirected to portal
- [ ] Registration page accessible without any env var flag
- [ ] `npm run build` passes ✅

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)